### PR TITLE
Feat/new metrics

### DIFF
--- a/deel/lip/__init__.py
+++ b/deel/lip/__init__.py
@@ -8,6 +8,7 @@ from . import constraints
 from . import initializers
 from . import layers
 from . import losses
+from . import metrics
 from .model import Sequential, Model, vanillaModel
 from . import normalizers
 from . import utils

--- a/deel/lip/metrics.py
+++ b/deel/lip/metrics.py
@@ -132,7 +132,8 @@ class ProvableAvgRobustness(tf.keras.losses.Loss):
         Compute the average provable robustness radius on the dataset.
 
         .. math::
-            \mathbb{E}_{x \in D}\left[ \frac{\mathcal{M}_f(x)}{L_f}\right]
+            \mathbb{E}_{x \in D}\left[ \frac{\phi\left(\mathcal{M}_f(x)\right)}{
+            L_f}\right]
 
         :math:`\mathcal{M}_f(x)` is a term that: is positive when x is correctly
         classified and negative otherwise. In both case the value give the robustness
@@ -154,8 +155,10 @@ class ProvableAvgRobustness(tf.keras.losses.Loss):
         \text{lip_const}` otherwise).
 
         When `negative_robustness` is set to `True` misclassified elements count as
-        negative robustness, when set to `False`, misclassified elements yield a
-        robustness radius of 0 (the elements are not ignored in both cases).
+        negative robustness (:math:`\phi` act as identity function), when set to
+        `False`,
+        misclassified elements yield a robustness radius of 0 ( :math:`\phi(x)=relu(
+        x)` ). The elements are not ignored when computing the mean in both cases.
 
         This metric works for labels both in {1,0} and {1,-1}.
 

--- a/deel/lip/metrics.py
+++ b/deel/lip/metrics.py
@@ -1,0 +1,149 @@
+# Copyright IRT Antoine de Saint Exupéry et Université Paul Sabatier Toulouse III - All
+# rights reserved. DEEL is a research program operated by IVADO, IRT Saint Exupéry,
+# CRIAQ and ANITI - https://www.deel.ai/
+# =====================================================================================
+"""
+This module contains metrics applicable in provable robustness. See
+https://arxiv.org/abs/2006.06520 for more information.
+"""
+import math
+import tensorflow as tf
+from tensorflow.keras.losses import Loss
+from tensorflow.keras.losses import Reduction
+from deel.lip.utils import _deel_export
+
+
+@_deel_export
+class ProvableRobustness(tf.keras.losses.Loss):
+    def __init__(
+        self,
+        l=1.0,
+        disjoint_neurons=True,
+        reduction=Reduction.AUTO,
+        name="ProvableRobustness",
+    ):
+        r"""
+        Compute the provable robustness, defined by :
+
+        .. math::
+            cert(x) = \frac{top_1 (y_i) - top_2(y_i)}{2l}
+
+
+        when `disjoint_neurons` is set to True, or
+
+        ..math::
+            cert(x) = \frac{top_1 (y_i) - top_2(y_i)}{l\sqrt{2}}
+
+
+        When `disjoint_neurons` is set to false.
+
+
+        Where l is the lipschitz constant of the network. Note that when your model
+        ends with a FrobeniusDense layer with parameter `disjoint_neurons=True` the
+        computation is slightly different ( see refences for more information ).
+
+        Notes:
+            This loss differs doesn't need y_true label to be computed.
+
+        References:
+            Serrurier et al. https://arxiv.org/abs/2006.06520
+
+        Args:
+            disjoint_neurons: must be set to True is your model ends with a
+                FrobeniusDense layer with `disjoint_neurons` set to True. Set to False
+                otherwise
+            name: metrics name.
+            **kwargs: parameters passed to the tf.keras.Loss constructor
+        """
+        self.l = l
+        self.disjoint_neurons = disjoint_neurons
+        if disjoint_neurons:
+            self.certificate_factor = 2 * l
+        else:
+            self.certificate_factor = math.sqrt(2) * l
+        super(ProvableRobustness, self).__init__(reduction, name)
+
+    def call(self, y_true, y_pred):
+        values, classes = tf.math.top_k(y_pred, k=2)
+        avg_robustness = tf.reduce_mean(
+            (values[:, 0] - values[:, 1]) / self.certificate_factor
+        )
+        return avg_robustness
+
+    def get_config(self):
+        config = {
+            "l": self.l,
+            "disjoint_neurons": self.disjoint_neurons,
+        }
+        base_config = super(ProvableRobustness, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))
+
+
+@_deel_export
+class AdjustedRobustness(Loss):
+    def __init__(
+        self,
+        l=1.0,
+        disjoint_neurons=True,
+        reduction=Reduction.AUTO,
+        name="AdjustedRobustness",
+    ):
+        r"""
+        Compute the adjusted robustness, defined by :
+
+        .. math::
+            cert_{acc}(x) = \frac{y_{i=label} - \max_{i \neq label} y_i}{2l}
+
+        when `disjoint_neurons` is set to True, or
+
+        .. math::
+            cert_{acc}(x) = \frac{y_{i=label} - \max_{i \neq label} y_i}{l\sqrt{2}}
+
+        When `disjoint_neurons` is set to false.
+
+
+        Where l is the lipschitz constant of the network. Note that when your model
+        ends with a FrobeniusDense layer with parameter `disjoint_neurons=True` the
+        computation is slightly different ( see refences for more information ).
+
+        Notes:
+            This loss differs from ProvableRobustness loss as a misclassification
+            from the model yield a negative certificate (this require the knowledge
+            of true labels)
+
+        References:
+            Serrurier et al. https://arxiv.org/abs/2006.06520
+
+        Args:
+            disjoint_neurons: must be set to True is your model ends with a
+                FrobeniusDense layer with `disjoint_neurons` set to True. Set to False
+                otherwise
+            name: metrics name.
+            **kwargs: parameters passed to the tf.keras.Loss constructor
+        """
+        self.l = l
+        self.disjoint_neurons = disjoint_neurons
+        if disjoint_neurons:
+            self.certificate_factor = 2 * l
+        else:
+            self.certificate_factor = math.sqrt(2) * l
+        super(AdjustedRobustness, self).__init__(reduction, name)
+
+    def call(self, y_true, y_pred):
+        values, classes = tf.math.top_k(y_pred, k=2)
+        robustness_bound = tf.where(
+            tf.argmax(y_pred, axis=-1) == tf.argmax(y_true, axis=-1),
+            (values[:, 0] - values[:, 1]) / self.certificate_factor,
+            -(values[:, 0] - values[:, 1]) / self.certificate_factor
+            # mislabelling => negative robustness
+        )
+        avg_robustness = tf.reduce_mean(robustness_bound)
+        return avg_robustness
+
+    def get_config(self):
+        config = {
+            "l": self.l,
+            "disjoint_neurons": self.disjoint_neurons,
+        }
+        base_config = super(AdjustedRobustness, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))

--- a/deel/lip/metrics.py
+++ b/deel/lip/metrics.py
@@ -10,10 +10,10 @@ import math
 import tensorflow as tf
 from tensorflow.keras.losses import Loss
 from tensorflow.keras.losses import Reduction
-from deel.lip.utils import _deel_export
+from tensorflow.keras.utils import register_keras_serializable
 
 
-@_deel_export
+@register_keras_serializable("deel-lip", "ProvableRobustness")
 class ProvableRobustness(tf.keras.losses.Loss):
     def __init__(
         self,
@@ -79,7 +79,7 @@ class ProvableRobustness(tf.keras.losses.Loss):
         return dict(list(base_config.items()) + list(config.items()))
 
 
-@_deel_export
+@register_keras_serializable("deel-lip", "AdjustedRobustness")
 class AdjustedRobustness(Loss):
     def __init__(
         self,

--- a/deel/lip/metrics.py
+++ b/deel/lip/metrics.py
@@ -78,7 +78,7 @@ class ProvableRobustAccuracy(Loss):
             epsilon: the metric will return the guaranteed accuracy for the radius
                 epsilon
             lip_const: lipschitz constant of the network
-            disjoint_neurons: must be set to True is your model ends with a
+            disjoint_neurons: must be set to True if your model ends with a
                 FrobeniusDense layer with `disjoint_neurons` set to True. Set to False
                 otherwise
             reduction: the recution method when training in a multi-gpu / TPU system

--- a/deel/lip/metrics.py
+++ b/deel/lip/metrics.py
@@ -101,11 +101,9 @@ class ProvableRobustAccuracy(Loss):
         else:
             delta_fct = _delta_binary
             self.certificate_factor = self.lip_const
-        return tf.reduce_mean(
-            tf.cast(
-                (delta_fct(y_true, y_pred) / self.certificate_factor) > self.epsilon,
-                y_pred.dtype,
-            )
+        return tf.cast(
+            (delta_fct(y_true, y_pred) / self.certificate_factor) > self.epsilon,
+            y_pred.dtype,
         )
 
     def get_config(self):
@@ -192,7 +190,7 @@ class ProvableAvgRobustness(Loss):
         else:
             delta_fct = _delta_binary
             self.certificate_factor = self.lip_const
-        return tf.reduce_mean(
+        return (
             self.delta_correction(delta_fct(y_true, y_pred)) / self.certificate_factor
         )
 

--- a/deel/lip/metrics.py
+++ b/deel/lip/metrics.py
@@ -61,7 +61,7 @@ def _delta_binary(y_true, y_pred):
 
 
 @register_keras_serializable("deel-lip", "ProvableRobustAccuracy")
-class ProvableRobustAccuracy(tf.keras.losses.Loss):
+class ProvableRobustAccuracy(Loss):
     def __init__(
         self,
         epsilon=36 / 255,
@@ -118,7 +118,7 @@ class ProvableRobustAccuracy(tf.keras.losses.Loss):
 
 
 @register_keras_serializable("deel-lip", "ProvableAvgRobustness")
-class ProvableAvgRobustness(tf.keras.losses.Loss):
+class ProvableAvgRobustness(Loss):
     def __init__(
         self,
         lip_const=1.0,

--- a/deel/lip/metrics.py
+++ b/deel/lip/metrics.py
@@ -4,80 +4,14 @@
 # =====================================================================================
 """
 This module contains metrics applicable in provable robustness. See
-https://arxiv.org/abs/2006.06520 for more information.
+https://arxiv.org/abs/2006.06520 and https://arxiv.org/abs/2108.04062 for more
+information.
 """
 import math
 import tensorflow as tf
 from tensorflow.keras.losses import Loss
 from tensorflow.keras.losses import Reduction
 from tensorflow.keras.utils import register_keras_serializable
-
-
-@register_keras_serializable("deel-lip", "ProvableRobustness")
-class ProvableRobustness(tf.keras.losses.Loss):
-    def __init__(
-        self,
-        lip_const=1.0,
-        disjoint_neurons=True,
-        reduction=Reduction.AUTO,
-        name="ProvableRobustness",
-    ):
-        r"""
-        Compute the provable robustness, defined by :
-
-        .. math::
-            cert(x) = \frac{top_1 (y_i) - top_2(y_i)}{2l}
-
-
-        when `disjoint_neurons` is set to True, or
-
-        ..math::
-            cert(x) = \frac{top_1 (y_i) - top_2(y_i)}{l\sqrt{2}}
-
-
-        When `disjoint_neurons` is set to false.
-
-
-        Where l is the lipschitz constant of the network. Note that when your model
-        ends with a FrobeniusDense layer with parameter `disjoint_neurons=True` the
-        computation is slightly different ( see refences for more information ).
-
-        Notes:
-            This loss differs doesn't need y_true label to be computed.
-
-        References:
-            Serrurier et al. https://arxiv.org/abs/2006.06520
-
-        Args:
-            lip_const: lipschitz constant of the network
-            disjoint_neurons: must be set to True is your model ends with a
-                FrobeniusDense layer with `disjoint_neurons` set to True. Set to False
-                otherwise
-            name: metrics name.
-            **kwargs: parameters passed to the tf.keras.Loss constructor
-        """
-        self.lip_const = lip_const
-        self.disjoint_neurons = disjoint_neurons
-        if disjoint_neurons:
-            self.certificate_factor = 2 * lip_const
-        else:
-            self.certificate_factor = math.sqrt(2) * lip_const
-        super(ProvableRobustness, self).__init__(reduction, name)
-
-    def call(self, y_true, y_pred):
-        values, classes = tf.math.top_k(y_pred, k=2)
-        avg_robustness = tf.reduce_mean(
-            (values[:, 0] - values[:, 1]) / self.certificate_factor
-        )
-        return avg_robustness
-
-    def get_config(self):
-        config = {
-            "lip_const": self.lip_const,
-            "disjoint_neurons": self.disjoint_neurons,
-        }
-        base_config = super(ProvableRobustness, self).get_config()
-        return dict(list(base_config.items()) + list(config.items()))
 
 
 def _delta_multiclass(y_true, y_pred):
@@ -152,7 +86,18 @@ class ProvableRobustAccuracy(tf.keras.losses.Loss):
         name="ProvableRobustAccuracy",
     ):
         r"""
-        TODO: write doc
+
+        The accuracy that can be proved at a given epsilon.
+
+        Args:
+            epsilon: the metric will return the guaranteed accuracy for the radius
+                epsilon
+            lip_const: lipschitz constant of the network
+            disjoint_neurons: must be set to True is your model ends with a
+                FrobeniusDense layer with `disjoint_neurons` set to True. Set to False
+                otherwise
+            reduction: the recution method when training in a multi-gpu / TPU system
+            name: metrics name.
         """
         self.lip_const = lip_const
         self.epsilon = epsilon
@@ -193,7 +138,44 @@ class ProvableAvgRobustness(tf.keras.losses.Loss):
         name="ProvableAvgRobustness",
     ):
         r"""
-        TODO: write doc
+
+        Compute the average provable robustness radius on the dataset.
+
+        .. math::
+            \mathbb{E}_{x \in D}\left[ \frac{\mathcal{M}_f(x)}{L_f}\right]
+
+        :math:`\mathcal{M}_f(x)` is a term that: is positive when x is correctly
+        classified and negative otherwise. In both case the value give the robustness
+        radius around x.
+
+        In the multiclass setup we have:
+
+        .. math::
+            \mathcal{M}_f(x) =f_l(x) - \max_{i \neq l} f_i(x)
+
+        In the binary classification setup we have:
+
+        .. math::
+            \mathcal{M}_f(x) = f(x) \text{ if } l=1, -f(x) \text{otherwise}
+
+        Where :math:`D` is the dataset, :math:`l` is the correct label for x and
+        :math:`L_f` is the lipschitz constant of the network (:math:`L = 2 \times
+        \text{lip_const}` when `disjoint_neurons=True`, :math:`L = \sqrt{2} \times
+        \text{lip_const}` otherwise).
+
+        When `negative_robustness` is set to `True` misclassified elements count as
+        negative robustness, when set to `False`, misclassified elements yield a
+        robustness radius of 0 (the elements are not ignored in both cases).
+
+        This metric works for labels both in {1,0} and {1,-1}.
+
+        Args:
+            lip_const: lipschitz constant of the network
+            disjoint_neurons: must be set to True is your model ends with a
+                FrobeniusDense layer with `disjoint_neurons` set to True. Set to False
+                otherwise
+            reduction: the recution method when training in a multi-gpu / TPU system
+            name: metrics name.
         """
         self.lip_const = lip_const
         self.disjoint_neurons = disjoint_neurons
@@ -220,167 +202,4 @@ class ProvableAvgRobustness(tf.keras.losses.Loss):
             "disjoint_neurons": self.disjoint_neurons,
         }
         base_config = super(ProvableAvgRobustness, self).get_config()
-        return dict(list(base_config.items()) + list(config.items()))
-
-
-@register_keras_serializable("deel-lip", "BinaryProvableRobustness")
-class BinaryProvableRobustness(tf.keras.losses.Loss):
-    def __init__(
-        self,
-        lip_const=1.0,
-        reduction=Reduction.AUTO,
-        name="BinaryProvableRobustness",
-    ):
-        r"""
-        Compute the provable robustness in the binary case, defined by :
-
-        .. math::
-            cert(x) = \frac{abs(y)}{l}
-
-        Where l is the lipschitz constant of the network. ( see refences for
-        more information ).
-
-        Notes:
-            This loss doesn't need y_true label to be computed.
-
-        References:
-            Serrurier et al. https://arxiv.org/abs/2006.06520
-
-        Args:
-            lip_const: lipschitz constant of the network.
-            name: metrics name.
-            **kwargs: parameters passed to the tf.keras.Loss constructor
-        """
-        self.lip_const = lip_const
-        super(BinaryProvableRobustness, self).__init__(reduction, name)
-
-    def call(self, y_true, y_pred):
-
-        avg_robustness = tf.reduce_mean(tf.reduce_mean(tf.abs(y_pred)) / self.lip_const)
-        return avg_robustness
-
-    def get_config(self):
-        config = {
-            "lip_const": self.lip_const,
-        }
-        base_config = super(BinaryProvableRobustness, self).get_config()
-        return dict(list(base_config.items()) + list(config.items()))
-
-
-@register_keras_serializable("deel-lip", "AdjustedRobustness")
-class AdjustedRobustness(Loss):
-    def __init__(
-        self,
-        lip_const=1.0,
-        disjoint_neurons=True,
-        reduction=Reduction.AUTO,
-        name="AdjustedRobustness",
-    ):
-        r"""
-        Compute the adjusted robustness, defined by :
-
-        .. math::
-            cert_{acc}(x) = \frac{y_{i=label} - \max_{i \neq label} y_i}{2l}
-
-        when `disjoint_neurons` is set to True, or
-
-        .. math::
-            cert_{acc}(x) = \frac{y_{i=label} - \max_{i \neq label} y_i}{l\sqrt{2}}
-
-        When `disjoint_neurons` is set to false.
-
-
-        Where l is the lipschitz constant of the network. Note that when your model
-        ends with a FrobeniusDense layer with parameter `disjoint_neurons=True` the
-        computation is slightly different ( see refences for more information ).
-
-        Notes:
-            This loss differs from ProvableRobustness loss as a misclassification
-            from the model yield a negative certificate (this require the knowledge
-            of true labels)
-
-        References:
-            Serrurier et al. https://arxiv.org/abs/2006.06520
-
-        Args:
-            lip_const: lipschitz constant of the network.
-            disjoint_neurons: must be set to True is your model ends with a
-                FrobeniusDense layer with `disjoint_neurons` set to True. Set to False
-                otherwise
-            name: metrics name.
-            **kwargs: parameters passed to the tf.keras.Loss constructor
-        """
-        self.lip_const = lip_const
-        self.disjoint_neurons = disjoint_neurons
-        if disjoint_neurons:
-            self.certificate_factor = 2 * lip_const
-        else:
-            self.certificate_factor = math.sqrt(2) * lip_const
-        super(AdjustedRobustness, self).__init__(reduction, name)
-
-    def call(self, y_true, y_pred):
-        values, classes = tf.math.top_k(y_pred, k=2)
-        robustness_bound = tf.where(
-            tf.argmax(y_pred, axis=-1) == tf.argmax(y_true, axis=-1),
-            (values[:, 0] - values[:, 1]) / self.certificate_factor,
-            -(values[:, 0] - values[:, 1]) / self.certificate_factor
-            # mislabelling => negative robustness
-        )
-        avg_robustness = tf.reduce_mean(robustness_bound)
-        return avg_robustness
-
-    def get_config(self):
-        config = {
-            "lip_const": self.lip_const,
-            "disjoint_neurons": self.disjoint_neurons,
-        }
-        base_config = super(AdjustedRobustness, self).get_config()
-        return dict(list(base_config.items()) + list(config.items()))
-
-
-@register_keras_serializable("deel-lip", "BinaryAdjustedRobustness")
-class BinaryAdjustedRobustness(tf.keras.losses.Loss):
-    def __init__(
-        self,
-        lip_const=1.0,
-        reduction=Reduction.AUTO,
-        name="BinaryAdjustedRobustness",
-    ):
-        r"""
-        Compute the adjusted robustness in the binary case, which is equivalent
-        to BinaryProvableRobustness but where a misclassified sample yield a
-        negative robustness.
-
-        .. math::
-            cert_{acc}(x) = \frac{y_{true}*y_{pred}}{2l}
-
-        Where l is the lipschitz constant of the network. In this equation, y_pred is
-        assumed to have values in {1,-1} for simplicity, however the metric works for
-        values in both {1,-1} and {1,0}.
-
-        Notes:
-            This loss differs from ProvableRobustness loss as a misclassification
-            from the model yield a negative certificate (this require the knowledge
-            of true labels)
-
-        Args:
-            lip_const: lipschitz constant of the network.
-            name: metrics name.
-            **kwargs: parameters passed to the tf.keras.Loss constructor
-        """
-        self.lip_const = lip_const
-        super(BinaryAdjustedRobustness, self).__init__(reduction, name)
-
-    def call(self, y_true, y_pred):
-        y_true = tf.sign(y_true - 1e-7)
-        avg_robustness = tf.reduce_mean(
-            tf.reduce_mean(y_pred * y_true) / self.lip_const
-        )
-        return avg_robustness
-
-    def get_config(self):
-        config = {
-            "lip_const": self.lip_const,
-        }
-        base_config = super(BinaryAdjustedRobustness, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))

--- a/deel/lip/metrics.py
+++ b/deel/lip/metrics.py
@@ -119,8 +119,8 @@ class ProvableRobustAccuracy(tf.keras.losses.Loss):
 
     def get_config(self):
         config = {
+            "epsilon": self.epsilon,
             "lip_const": self.lip_const,
-            "espilon": self.epsilon,
             "disjoint_neurons": self.disjoint_neurons,
         }
         base_config = super(ProvableRobustAccuracy, self).get_config()
@@ -200,6 +200,7 @@ class ProvableAvgRobustness(tf.keras.losses.Loss):
         config = {
             "lip_const": self.lip_const,
             "disjoint_neurons": self.disjoint_neurons,
+            "negative_robustness": self.negative_robustness,
         }
         base_config = super(ProvableAvgRobustness, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))

--- a/deel/lip/metrics.py
+++ b/deel/lip/metrics.py
@@ -17,7 +17,7 @@ from tensorflow.keras.utils import register_keras_serializable
 class ProvableRobustness(tf.keras.losses.Loss):
     def __init__(
         self,
-        l=1.0,
+        lip_const=1.0,
         disjoint_neurons=True,
         reduction=Reduction.AUTO,
         name="ProvableRobustness",
@@ -49,18 +49,19 @@ class ProvableRobustness(tf.keras.losses.Loss):
             Serrurier et al. https://arxiv.org/abs/2006.06520
 
         Args:
+            lip_const: lipschitz constant of the network
             disjoint_neurons: must be set to True is your model ends with a
                 FrobeniusDense layer with `disjoint_neurons` set to True. Set to False
                 otherwise
             name: metrics name.
             **kwargs: parameters passed to the tf.keras.Loss constructor
         """
-        self.l = l
+        self.lip_const = lip_const
         self.disjoint_neurons = disjoint_neurons
         if disjoint_neurons:
-            self.certificate_factor = 2 * l
+            self.certificate_factor = 2 * lip_const
         else:
-            self.certificate_factor = math.sqrt(2) * l
+            self.certificate_factor = math.sqrt(2) * lip_const
         super(ProvableRobustness, self).__init__(reduction, name)
 
     def call(self, y_true, y_pred):
@@ -72,7 +73,7 @@ class ProvableRobustness(tf.keras.losses.Loss):
 
     def get_config(self):
         config = {
-            "l": self.l,
+            "lip_const": self.lip_const,
             "disjoint_neurons": self.disjoint_neurons,
         }
         base_config = super(ProvableRobustness, self).get_config()
@@ -83,7 +84,7 @@ class ProvableRobustness(tf.keras.losses.Loss):
 class AdjustedRobustness(Loss):
     def __init__(
         self,
-        l=1.0,
+        lip_const=1.0,
         disjoint_neurons=True,
         reduction=Reduction.AUTO,
         name="AdjustedRobustness",
@@ -115,18 +116,19 @@ class AdjustedRobustness(Loss):
             Serrurier et al. https://arxiv.org/abs/2006.06520
 
         Args:
+            lip_const: lipschitz constant of the network.
             disjoint_neurons: must be set to True is your model ends with a
                 FrobeniusDense layer with `disjoint_neurons` set to True. Set to False
                 otherwise
             name: metrics name.
             **kwargs: parameters passed to the tf.keras.Loss constructor
         """
-        self.l = l
+        self.lip_const = lip_const
         self.disjoint_neurons = disjoint_neurons
         if disjoint_neurons:
-            self.certificate_factor = 2 * l
+            self.certificate_factor = 2 * lip_const
         else:
-            self.certificate_factor = math.sqrt(2) * l
+            self.certificate_factor = math.sqrt(2) * lip_const
         super(AdjustedRobustness, self).__init__(reduction, name)
 
     def call(self, y_true, y_pred):
@@ -142,7 +144,7 @@ class AdjustedRobustness(Loss):
 
     def get_config(self):
         config = {
-            "l": self.l,
+            "lip_const": self.lip_const,
             "disjoint_neurons": self.disjoint_neurons,
         }
         base_config = super(AdjustedRobustness, self).get_config()

--- a/deel/lip/metrics.py
+++ b/deel/lip/metrics.py
@@ -93,6 +93,7 @@ class ProvableRobustAccuracy(Loss):
             self.certificate_factor = math.sqrt(2) * lip_const
         super(ProvableRobustAccuracy, self).__init__(reduction, name)
 
+    @tf.function
     def call(self, y_true, y_pred):
         shape = y_true.shape
         if len(shape) == 2 and (shape[-1] > 1):
@@ -183,6 +184,7 @@ class ProvableAvgRobustness(Loss):
             self.delta_correction = tf.nn.relu
         super(ProvableAvgRobustness, self).__init__(reduction, name)
 
+    @tf.function
     def call(self, y_true, y_pred):
         shape = y_true.shape
         if len(shape) == 2 and (shape[-1] > 1):

--- a/deel/lip/metrics.py
+++ b/deel/lip/metrics.py
@@ -104,7 +104,7 @@ class ProvableRobustAccuracy(Loss):
         return tf.reduce_mean(
             tf.cast(
                 (delta_fct(y_true, y_pred) / self.certificate_factor) > self.epsilon,
-                tf.float32,
+                y_pred.dtype,
             )
         )
 

--- a/deel/lip/metrics.py
+++ b/deel/lip/metrics.py
@@ -31,9 +31,9 @@ def _delta_multiclass(y_true, y_pred):
 
     """
     ynl_shape = (-1, tf.shape(y_pred)[-1] - 1)
-    yl = tf.boolean_mask(y_pred, y_true == 1)
+    yl = tf.boolean_mask(y_pred, y_true > 0)
     ynl = tf.reshape(
-        tf.boolean_mask(y_pred, y_true != 1),
+        tf.boolean_mask(y_pred, y_true <= 0),
         ynl_shape,
     )
     delta = yl - tf.reduce_max(ynl, axis=-1)

--- a/deel/lip/metrics.py
+++ b/deel/lip/metrics.py
@@ -80,6 +80,52 @@ class ProvableRobustness(tf.keras.losses.Loss):
         return dict(list(base_config.items()) + list(config.items()))
 
 
+@register_keras_serializable("deel-lip", "BinaryProvableRobustness")
+class BinaryProvableRobustness(tf.keras.losses.Loss):
+    def __init__(
+        self,
+        lip_const=1.0,
+        reduction=Reduction.AUTO,
+        name="BinaryProvableRobustness",
+    ):
+        r"""
+        Compute the provable robustness in the binary case, defined by :
+
+        .. math::
+            cert(x) = \frac{abs(y)}{l}
+
+        Where l is the lipschitz constant of the network. ( see refences for
+        more information ).
+
+        Notes:
+            This loss doesn't need y_true label to be computed.
+
+        References:
+            Serrurier et al. https://arxiv.org/abs/2006.06520
+
+        Args:
+            lip_const: lipschitz constant of the network.
+            name: metrics name.
+            **kwargs: parameters passed to the tf.keras.Loss constructor
+        """
+        self.lip_const = lip_const
+        super(BinaryProvableRobustness, self).__init__(reduction, name)
+
+    def call(self, y_true, y_pred):
+
+        avg_robustness = tf.reduce_mean(
+            tf.reduce_mean(tf.abs(y_pred)) / self.lip_const
+        )
+        return avg_robustness
+
+    def get_config(self):
+        config = {
+            "lip_const": self.lip_const,
+        }
+        base_config = super(BinaryProvableRobustness, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))
+
+
 @register_keras_serializable("deel-lip", "AdjustedRobustness")
 class AdjustedRobustness(Loss):
     def __init__(

--- a/doc/source/deel.lip.rst
+++ b/doc/source/deel.lip.rst
@@ -13,6 +13,7 @@ Submodules
    deel.lip.initializers
    deel.lip.layers
    deel.lip.losses
+   deel.lip.metrics
    deel.lip.model
    deel.lip.normalizers
    deel.lip.utils

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,127 @@
+import unittest
+from unittest import TestCase
+import tensorflow as tf
+from tensorflow.keras.models import Sequential
+from tensorflow.keras.layers import Input, Dense
+from tensorflow.keras.optimizers import SGD
+from deel.lip.utils import load_model
+from deel.lip.metrics import (
+    ProvableRobustness,
+    AdjustedRobustness,
+    BinaryAdjustedRobustness,
+    BinaryProvableRobustness,
+)
+import os
+
+
+def check_serialization(nb_class, loss):
+    m = Sequential([Input(10), Dense(nb_class)])
+    m.compile(optimizer=SGD(), loss=loss)
+    name = loss.__class__.__name__
+    path = os.path.join("logs", "losses", name)
+    m.save(path)
+    m2 = load_model(path, compile=True)
+    m2(tf.random.uniform((255, 10)))
+
+
+class Test(TestCase):
+    def test_serialization(self):
+        pr = ProvableRobustness(1.0, False)
+        check_serialization(1, pr)
+        ar = AdjustedRobustness(2.0, False)
+        check_serialization(1, ar)
+        bar = BinaryAdjustedRobustness(1.0)
+        check_serialization(1, bar)
+        bpr = BinaryProvableRobustness(1.0)
+        check_serialization(1, bpr)
+
+    def test_provable_vs_adjusted(self):
+        n = 500
+        x1 = tf.random.normal((n, 10), mean=0.0, stddev=0.1)
+        x2 = tf.random.normal((n, 10), mean=1.0, stddev=0.1)
+        for l in [1.0, 0.5, 2.0]:
+            for disjoint in [True, False]:
+                pr = ProvableRobustness(l, disjoint)
+                ar = AdjustedRobustness(l, disjoint)
+                l1 = pr(x1, x1).numpy()
+                l2 = ar(x1, x1).numpy()
+                self.assertAlmostEqual(
+                    l1,
+                    l2,
+                    4,
+                    msg="provable and adjusted "
+                    "robustness must give same "
+                    "values when y_true==y_pred",
+                )
+                l1 = pr(x1, x2).numpy()
+                l2 = ar(x1, x2).numpy()
+                self.assertNotAlmostEqual(
+                    l1,
+                    l2,
+                    4,
+                    msg="provable and adjusted robustness must give different values"
+                    " when y_true!=y_pred",
+                )
+
+        x1 = tf.random.normal((n, 10), mean=0.0, stddev=0.1)
+        x2 = tf.random.normal((n, 10), mean=1.0, stddev=0.1)
+        for l in [1.0, 0.5, 2.0]:
+            bar = BinaryAdjustedRobustness(l)
+            bpr = BinaryProvableRobustness(l)
+            l1 = bpr(x1, x1).numpy()
+            l2 = bar(x1, x1).numpy()
+            self.assertAlmostEqual(
+                l1,
+                l2,
+                4,
+                msg="provable and adjusted robustness must give same values when y_"
+                "true==y_pred",
+            )
+            l1 = bpr(x1, x2).numpy()
+            l2 = bar(x1, x2).numpy()
+            self.assertNotAlmostEqual(
+                l1,
+                l2,
+                4,
+                msg="provable and adjusted robustness must give different values when "
+                "y_true!=y_pred",
+            )
+
+    def test_data_format(self):
+        pr = ProvableRobustness(1.0, False)
+        ar = AdjustedRobustness(2.0, False)
+        bar = BinaryAdjustedRobustness(1.0)
+        bpr = BinaryProvableRobustness(1.0)
+        n = 500
+        for metric in [pr, ar]:
+            y_pred = tf.random.normal((n, 10), mean=0.0, stddev=0.1)
+            y_true = tf.random.normal((n, 10), mean=0.0, stddev=0.1)
+            metrics_values = []
+            for neg_val in [0.0, -1.0]:
+                y_pred_case = y_pred
+                y_true_case = tf.where(y_true > 0, 1.0, neg_val)
+                metrics_values.append(metric(y_true_case, y_pred_case).numpy())
+            self.assertTrue(
+                all([m == metrics_values[0] for m in metrics_values]),
+                "changing the data format must not change the metric " "value",
+            )
+        for metric in [bar, bpr]:
+            y_pred = tf.random.normal((n,), mean=0.0, stddev=0.1)
+            y_true = tf.random.normal((n,), mean=0.0, stddev=0.1)
+            metrics_values = []
+            for expand_dim in [True, False]:
+                for neg_val in [0.0, -1.0]:
+                    y_pred_case = y_pred
+                    y_true_case = tf.where(y_true > 0, 1.0, neg_val)
+                    if expand_dim:
+                        y_true_case = tf.expand_dims(y_true_case, -1)
+                        y_pred_case = tf.expand_dims(y_pred_case, -1)
+                    metrics_values.append(metric(y_true_case, y_pred_case).numpy())
+            self.assertTrue(
+                all([m == metrics_values[0] for m in metrics_values]),
+                "changing the data format must not change the metric " "value",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -140,7 +140,7 @@ class Test(TestCase):
         n = 500
         # check in multiclass
         metrics_values = defaultdict(list)
-        y_pred = tf.random.normal((n, 10), mean=0.0, stddev=0.1)
+        y_pred = tf.random.normal((n, 10), mean=0.0, stddev=1.0)
         y_true = tf.one_hot(tf.convert_to_tensor(np.random.randint(10, size=n)), 10)
         for neg_val in [0.0, -1.0]:
             y_pred_case = y_pred
@@ -153,21 +153,15 @@ class Test(TestCase):
             metrics_values["negative_rob"].append(
                 ar(y_true_case, y_pred_case * (np.sqrt(2) / 2.0)).numpy()
             )
-        self.assertTrue(
-            all(
-                [m == metrics_values["standard"][0] for m in metrics_values["standard"]]
-            ),
-            "the loss does not account disjoint_neuron properly in multiclass",
-        )
-        self.assertTrue(
-            all(
-                [
-                    m == metrics_values["negative_rob"][0]
-                    for m in metrics_values["negative_rob"]
-                ]
-            ),
-            "the loss does not account disjoint_neuron properly in multiclass",
-        )
+        print(metrics_values)
+        for metric_type in ["standard", "negative_rob"]:
+            for m in metrics_values[metric_type]:
+                self.assertAlmostEqual(
+                    m,
+                    metrics_values[metric_type][0],
+                    4,
+                    "the loss does not account disjoint_neuron properly in multiclass",
+                )
         # check in binary
         metrics_values = defaultdict(list)
         y_pred = tf.random.normal((n,), mean=0.0, stddev=0.1)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -39,10 +39,10 @@ class Test(TestCase):
         n = 500
         x1 = tf.random.normal((n, 10), mean=0.0, stddev=0.1)
         x2 = tf.random.normal((n, 10), mean=1.0, stddev=0.1)
-        for l in [1.0, 0.5, 2.0]:
+        for lip_cst in [1.0, 0.5, 2.0]:
             for disjoint in [True, False]:
-                pr = ProvableRobustness(l, disjoint)
-                ar = AdjustedRobustness(l, disjoint)
+                pr = ProvableRobustness(lip_cst, disjoint)
+                ar = AdjustedRobustness(lip_cst, disjoint)
                 l1 = pr(x1, x1).numpy()
                 l2 = ar(x1, x1).numpy()
                 self.assertAlmostEqual(
@@ -65,9 +65,9 @@ class Test(TestCase):
 
         x1 = tf.random.normal((n, 10), mean=0.0, stddev=0.1)
         x2 = tf.random.normal((n, 10), mean=1.0, stddev=0.1)
-        for l in [1.0, 0.5, 2.0]:
-            bar = BinaryAdjustedRobustness(l)
-            bpr = BinaryProvableRobustness(l)
+        for lip_cst in [1.0, 0.5, 2.0]:
+            bar = BinaryAdjustedRobustness(lip_cst)
+            bpr = BinaryProvableRobustness(lip_cst)
             l1 = bpr(x1, x1).numpy()
             l2 = bar(x1, x1).numpy()
             self.assertAlmostEqual(

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -197,8 +197,39 @@ class Test(TestCase):
         )
 
     def test_hardcoded_values(self):
-        pr = ProvableRobustAccuracy(1.0, False)
-        ar = ProvableAvgRobustness(2.0, False)
+        pr = ProvableRobustAccuracy(0.25, 1.0, False)
+        ar = ProvableAvgRobustness(1.0, False)
+        y_pred = tf.convert_to_tensor(
+            [
+                [1.0, 0.0, 0.0],  # good class & over 0.25
+                [0.1, 0.0, 0.0],  # good class & below 0.25
+                [0.0, 0.0, 1.0],  # wrong class & over 0.25
+                [0.0, 0.0, 0.1],  # wrong class & below 0.25
+            ]
+        )
+        y_true = tf.convert_to_tensor(
+            [
+                [1.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 1.0, 0.0],
+            ]
+        )
+        self.assertEqual(
+            pr(y_true, y_pred).numpy(),
+            0.25,
+            "ProvableRobustAccuracy did not "
+            "get the expected result with "
+            "hardcoded values ",
+        )
+        self.assertAlmostEqual(
+            ar(y_true, y_pred).numpy(),
+            0.25 * 1.1 / np.sqrt(2),
+            5,
+            "ProvableAvgRobustness did not "
+            "get the expected result with "
+            "hardcoded values ",
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -14,35 +14,48 @@ import numpy as np
 import os
 
 
-def check_serialization(nb_class, loss):
-    m = Sequential([Input(10), Dense(nb_class)])
+def check_serialization(nb_class, loss, nb_classes):
+    n = 255
+    x = tf.random.uniform((n, 42))
+    y = tf.one_hot(
+        tf.convert_to_tensor(np.random.randint(nb_classes, size=n)), nb_classes
+    )
+    m = Sequential([Input(42), Dense(nb_class)])
     m.compile(optimizer=SGD(), loss=loss)
+    l1 = m.evaluate(x, y)
     name = loss.__class__.__name__
     path = os.path.join("logs", "losses", name)
     m.save(path)
     m2 = load_model(path, compile=True)
-    m2(tf.random.uniform((255, 10)))
+    l2 = m2.evaluate(x, y)
+    return l1, l2
 
 
 class Test(TestCase):
     def test_serialization(self):
         pra = ProvableRobustAccuracy(1, 1.0, disjoint_neurons=False)
-        check_serialization(1, pra)
+        l1, l2 = check_serialization(10, pra, 10)
+        self.assertEqual(
+            l1, l2, "serialization changed loss value for ProvableRobustAccuracy"
+        )
         par = ProvableAvgRobustness(
             2.0, disjoint_neurons=False, negative_robustness=True
         )
-        check_serialization(1, par)
+        l1, l2 = check_serialization(10, par, 10)
+        self.assertEqual(
+            l1, l2, "serialization changed loss value for ProvableAvgRobustness"
+        )
 
     def test_provable_vs_adjusted(self):
         n = 500
-        x1 = tf.random.normal((n, 10), mean=0.0, stddev=0.1)
-        x2 = tf.random.normal((n, 10), mean=1.0, stddev=0.1)
+        x = tf.random.normal((n, 10), mean=0.0, stddev=0.1)
+        y = tf.one_hot(tf.convert_to_tensor(np.random.randint(10, size=n)), 10)
         for lip_cst in [1, 0.5, 2.0]:
             for disjoint in [True, False]:
                 pr = ProvableAvgRobustness(lip_cst, disjoint, negative_robustness=False)
                 ar = ProvableAvgRobustness(lip_cst, disjoint, negative_robustness=True)
-                l1 = pr(x1, x1).numpy()
-                l2 = ar(x1, x1).numpy()
+                l1 = pr(y, y).numpy()
+                l2 = ar(y, y).numpy()
                 self.assertAlmostEqual(
                     l1,
                     l2,
@@ -51,8 +64,8 @@ class Test(TestCase):
                     "robustness must give same "
                     "values when y_true==y_pred",
                 )
-                l1 = pr(x1, x2).numpy()
-                l2 = ar(x1, x2).numpy()
+                l1 = pr(y, x).numpy()
+                l2 = ar(y, x).numpy()
                 self.assertNotAlmostEqual(
                     l1,
                     l2,
@@ -61,13 +74,13 @@ class Test(TestCase):
                     " when y_true!=y_pred",
                 )
 
-        x1 = tf.random.normal((n, 10), mean=0.0, stddev=0.1)
-        x2 = tf.random.normal((n, 10), mean=1.0, stddev=0.1)
+        x = tf.random.normal((n, 10), mean=0.0, stddev=0.1)
+        y = tf.one_hot(tf.convert_to_tensor(np.random.randint(10, size=n)), 10)
         for lip_cst in [1.0, 0.5, 2.0]:
             bpr = ProvableAvgRobustness(lip_cst, disjoint, negative_robustness=False)
             bar = ProvableAvgRobustness(lip_cst, disjoint, negative_robustness=True)
-            l1 = bpr(x1, x1).numpy()
-            l2 = bar(x1, x1).numpy()
+            l1 = bpr(y, y).numpy()
+            l2 = bar(y, y).numpy()
             self.assertAlmostEqual(
                 l1,
                 l2,
@@ -75,8 +88,8 @@ class Test(TestCase):
                 msg="provable and adjusted robustness must give same values when y_"
                 "true==y_pred",
             )
-            l1 = bpr(x1, x2).numpy()
-            l2 = bar(x1, x2).numpy()
+            l1 = pr(y, x).numpy()
+            l2 = ar(y, x).numpy()
             self.assertNotAlmostEqual(
                 l1,
                 l2,
@@ -163,14 +176,11 @@ class Test(TestCase):
         for neg_val in [0.0, -1.0]:
             y_pred_case = y_pred
             y_true_case = tf.where(y_true > 0, 1.0, neg_val)
+            # no sqrt(2)/2 here as the corrective factor works only in multiclass
             metrics_values["standard"].append(pdr(y_true_case, y_pred_case).numpy())
-            metrics_values["standard"].append(
-                pr(y_true_case, y_pred_case * (np.sqrt(2) / 2.0)).numpy()
-            )
+            metrics_values["standard"].append(pr(y_true_case, y_pred_case).numpy())
             metrics_values["negative_rob"].append(adr(y_true_case, y_pred_case).numpy())
-            metrics_values["negative_rob"].append(
-                ar(y_true_case, y_pred_case * (np.sqrt(2) / 2.0)).numpy()
-            )
+            metrics_values["negative_rob"].append(ar(y_true_case, y_pred_case).numpy())
         self.assertTrue(
             all(
                 [m == metrics_values["standard"][0] for m in metrics_values["standard"]]

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -129,7 +129,7 @@ class Test(TestCase):
                     metrics_values.append(metric(y_true_case, y_pred_case).numpy())
             self.assertTrue(
                 all([m == metrics_values[0] for m in metrics_values]),
-                "changing the data format must not change the metric " "value",
+                "changing the data format must not change the metric value",
             )
 
     def test_disjoint_neurons(self):

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -2,10 +2,9 @@ import unittest
 from collections import defaultdict
 from unittest import TestCase
 import tensorflow as tf
-from tensorflow.keras.models import Sequential
+from tensorflow.keras.models import Sequential, load_model
 from tensorflow.keras.layers import Input, Dense
 from tensorflow.keras.optimizers import SGD
-from deel.lip.utils import load_model
 from deel.lip.metrics import (
     ProvableRobustAccuracy,
     ProvableAvgRobustness,


### PR DESCRIPTION
added new metrics:
- ProvableAvgRobustness: return the average size of provable radius ( for both binary and multiclass ) there is a parameter to choose if misclassified examples gives a 0 radius or a negative radius.
- ProvableRobustAccuracy: return the accuracy that can be guaranteed for a given epsilon.

Also added tests for these metrics