### PR TITLE
Refactor vanilla export for model

### DIFF
--- a/deel/lip/model.py
+++ b/deel/lip/model.py
@@ -7,14 +7,12 @@ This module contains equivalents for Model and Sequential. These classes add sup
 for condensation and vanilla exportation.
 """
 import math
-from typing import Dict
 from warnings import warn
 import numpy as np
-from tensorflow import Tensor
 from tensorflow.keras import Sequential as KerasSequential, Model as KerasModel
-from tensorflow.keras.layers import Input, InputLayer
 from .layers import LipschitzLayer, Condensable
 from tensorflow.keras.utils import register_keras_serializable
+from tensorflow.keras.models import clone_model
 
 
 @register_keras_serializable("deel-lip", "Sequential")
@@ -99,19 +97,7 @@ class Sequential(KerasSequential, LipschitzLayer, Condensable):
                 layer.condense()
 
     def vanilla_export(self):
-        layers = list()
-        if hasattr(self, "input"):
-            layers.append(Input(self.input.shape[1:], dtype=self.input.dtype))
-        for layer in self.layers:
-            if isinstance(layer, Condensable):
-                layers.append(layer.vanilla_export())
-            else:
-                lay_cp = layer.__class__.from_config(layer.get_config())
-                lay_cp.build(layer.input.shape[1:])
-                lay_cp.set_weights(layer.get_weights())
-                layers.append(lay_cp)
-        model = KerasSequential(layers, self.name)
-        return model
+        return vanillaModel(self)
 
     def get_config(self):
         config = {"k_coef_lip": self.k_coef_lip}
@@ -145,56 +131,32 @@ class Model(KerasModel):
             been replaced with their vanilla equivalent (e.g. SpectralConv2D with
              Conv2D).
         """
-        # Dictionary that will map tensor names (from the current model) to tensors
-        # in the exported model.# We initialize the dictionary for inputs:
-        tensors: Dict[str, Tensor] = {}
-
-        # Initialize the dictionary with inputs:
-        tensors.update({inp.name: Input(shape=inp.shape[1:]) for inp in self.inputs})
-
-        for lay in self.layers:
-
-            # Skip input layers:
-            if isinstance(lay, InputLayer):
-                continue
-
-            # Condense+Export the layer if it is a non-vanilla layer, otherwise
-            # just copy the layer:
-            if isinstance(lay, Condensable):
-                lay_cp = lay.vanilla_export()
-            else:
-                # Duplicate layer (weights are not duplicated):
-                lay_cp = lay.__class__.from_config(lay.get_config())
-                lay_cp.build(lay.input_shape)
-                lay_cp.set_weights(lay.get_weights().copy())
-
-            # For each input nodes, we are going to create corresponding operations
-            # in the exported models:
-            for inode in range(len(lay.inbound_nodes)):
-                inputs = lay.get_input_at(inode)
-                outputs = lay.get_output_at(inode)
-
-                # Fetch the
-                if isinstance(inputs, list):
-                    inputs = [tensors[input.name] for input in inputs]
-                else:
-                    inputs = tensors[inputs.name]
-
-                # Retrieve outputs layers (for the exported layer):
-                moutputs = lay_cp(inputs)
-
-                # Add the output tensors to the dictionary, using the names from the
-                # original model:
-                if isinstance(outputs, list):
-                    for outi, mouti in zip(outputs, moutputs):
-                        tensors[outi.name] = mouti
-                else:
-                    tensors[outputs.name] = moutputs
-
-        return KerasModel(
-            [tensors[inp.name] for inp in self.inputs],
-            [tensors[out.name] for out in self.outputs],
-        )
+        return vanillaModel(self)
 
 
-vanillaModel = Model.vanilla_export
+def vanillaModel(model):
+    """
+    Transform a model to its equivalent "vanilla" model, i.e. a model where
+    `Condensable` layers are replaced with their vanilla equivalent. For example,
+    `SpectralConv2D` layers are converted to tf.keras `Conv2D` layers.
+
+    The input model can be a tf.keras Sequential/Model or a deel.lip Sequential/Model.
+
+    Args:
+        model: a tf.keras or deel.lip model with Condensable layers.
+
+    Returns:
+        A Keras model, identical to the input model where `Condensable` layers are
+            replaced with their vanilla counterparts.
+    """
+
+    def _replace_condensable_layer(layer):
+        # Return a vanilla layer if Condensable, else return a copy of the layer
+        if isinstance(layer, Condensable):
+            return layer.vanilla_export()
+        new_layer = layer.__class__.from_config(layer.get_config())
+        new_layer.build(layer.input_shape)
+        new_layer.set_weights(layer.get_weights())
+        return new_layer
+
+    return clone_model(model, clone_function=_replace_condensable_layer)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,70 @@
+"""These tests assert that deel.lip Sequential and Model objects behave as expected."""
+
+from unittest import TestCase
+import numpy as np
+import tensorflow as tf
+from deel.lip import Sequential, Model, vanillaModel
+from deel.lip.layers import SpectralConv2D, SpectralDense, ScaledL2NormPooling2D
+from deel.lip.activations import GroupSort2
+
+
+def sequential_layers():
+    """Return list of layers for a Sequential model"""
+    return [
+        SpectralConv2D(6, 3, input_shape=(20, 20, 3)),
+        ScaledL2NormPooling2D(),
+        GroupSort2(),
+        tf.keras.layers.Flatten(),
+        SpectralDense(10),
+    ]
+
+
+def functional_input_output_tensors():
+    """Return input and output tensor of a Functional (hard-coded) model"""
+    inputs = tf.keras.Input((8, 8, 3))
+    x = SpectralConv2D(2, (3, 3), k_coef_lip=2.0)(inputs)
+    x = GroupSort2()(x)
+    x = ScaledL2NormPooling2D((2, 2), k_coef_lip=2.0)(x)
+    x1 = SpectralConv2D(2, (3, 3), k_coef_lip=2.0)(x)
+    x1 = GroupSort2()(x1)
+    x = tf.keras.layers.Add()([x, x1])
+    x = tf.keras.layers.Flatten()(x)
+    x = tf.keras.layers.Dense(4)(x)
+    x = SpectralDense(4, k_coef_lip=2.0)(x)
+    outputs = SpectralDense(2, k_coef_lip=2.0)(x)
+    return inputs, outputs
+
+
+class Test(TestCase):
+    def assert_model_outputs(self, model1, model2):
+        """Assert outputs are identical for both models on random inputs"""
+        x = np.random.random((10,) + model1.input_shape[1:]).astype(np.float32)
+        y1 = model1.predict(x)
+        y2 = model2.predict(x)
+        np.testing.assert_array_equal(y2, y1)
+
+    def test_keras_Sequential(self):
+        """Assert vanilla conversion of a tf.keras.Sequential model"""
+        model = tf.keras.Sequential(sequential_layers())
+        vanilla_model = vanillaModel(model)
+        self.assert_model_outputs(model, vanilla_model)
+
+    def test_deel_lip_Sequential(self):
+        """Assert vanilla conversion of a deel.lip.Sequential model"""
+        model = Sequential(sequential_layers())
+        vanilla_model = model.vanilla_export()
+        self.assert_model_outputs(model, vanilla_model)
+
+    def test_keras_Model(self):
+        """Assert vanilla conversion of a tf.keras.Model model"""
+        inputs, outputs = functional_input_output_tensors()
+        model = tf.keras.Model(inputs, outputs)
+        vanilla_model = vanillaModel(model)
+        self.assert_model_outputs(model, vanilla_model)
+
+    def test_deel_lip_Model(self):
+        """Assert vanilla conversion of a deel.lip.Model model"""
+        inputs, outputs = functional_input_output_tensors()
+        model = Model(inputs, outputs)
+        vanilla_model = model.vanilla_export()
+        self.assert_model_outputs(model, vanilla_model)


### PR DESCRIPTION
The vanilla export functions for models are refactored and simplified by using the `tf.keras.model.clone_model()` function. 
Unit tests are added to verify that model outputs from a Lipschitz model and its vanilla equivalent are identical.