### PR TITLE
PadConv2D

### DIFF
--- a/deel/lip/layers.py
+++ b/deel/lip/layers.py
@@ -792,9 +792,7 @@ class FrobeniusConv2D(keraslayers.Conv2D, LipschitzLayer, Condensable):
         return dict(list(base_config.items()) + list(config.items()))
 
     def condense(self):
-        wbar = (
-            self.kernel / tf.norm(self.kernel, axis=self.axis_norm) * self._get_coef()
-        )
+        wbar = self.kernel / tf.norm(self.kernel) * self._get_coef()
         self.kernel.assign(wbar)
 
     def vanilla_export(self):

--- a/deel/lip/layers.py
+++ b/deel/lip/layers.py
@@ -505,21 +505,7 @@ class SpectralConv2D(keraslayers.Conv2D, LipschitzLayer, Condensable):
         else:
             sn1 = self.strides[0]
             sn2 = self.strides[1]
-            ho = np.floor(h / sn1)
-            wo = np.floor(w / sn2)
-            alphabar1 = np.floor(k1_div2 / sn1)
-            alphabar2 = np.floor(k2_div2 / sn2)
-            betabar1 = k1_div2 - alphabar1 * sn1
-            betabar2 = k2_div2 - alphabar2 * sn2
-            zl1 = (alphabar1 * sn1 + 2 * betabar1) * (alphabar1 + 1) / 2
-            zl2 = (alphabar2 * sn2 + 2 * betabar2) * (alphabar2 + 1) / 2
-            gamma1 = h - 1 - sn1 * np.ceil((h - 1 - k1_div2) / sn1)
-            gamma2 = w - 1 - sn2 * np.ceil((w - 1 - k2_div2) / sn2)
-            alphah1 = np.floor(gamma1 / sn1)
-            alphaw2 = np.floor(gamma2 / sn2)
-            zr1 = (alphah1 + 1) * (k1_div2 - gamma1 + sn1 * alphah1 / 2.0)
-            zr2 = (alphaw2 + 1) * (k2_div2 - gamma2 + sn2 * alphaw2 / 2.0)
-            coefLip = np.sqrt((h * w) / ((k1 * ho - zl1 - zr1) * (k2 * wo - zl2 - zr2)))
+            coefLip = np.sqrt(1.0 / (np.ceil(k1 / sn1) * np.ceil(k2 / sn2)))
         return coefLip
 
     def call(self, x, training=True):

--- a/deel/lip/normalizers.py
+++ b/deel/lip/normalizers.py
@@ -96,14 +96,16 @@ def _power_iteration(w, u, eps=DEFAULT_EPS_SPECTRAL):
          u and v corresponding to the maximum eigenvalue
 
     """
-    # build _u and _v
+    # build _u and _v (_v is size of _u@tf.transpose(w), will be set on the first body
+    # iteration)
     _u = u
-    _v = tf.math.l2_normalize(_u @ tf.transpose(w))
-    # create a fake old_w that does'nt pass the loop condition
-    # it won't affect computation as the firt action done in the loop overwrite it.
-    _old_u = 10 * _u
-    # define the loop condition
+    _v = tf.zeros(u.shape[:-1] + (w.shape[0],), dtype=w.dtype)
 
+    # create a fake old_w that doesn't pass the loop condition
+    # it won't affect computation as the first action done in the loop overwrite it.
+    _old_u = 10 * _u
+
+    # define the loop condition
     def cond(_u, _v, old_u):
         return tf.linalg.norm(_u - old_u) >= eps
 

--- a/deel/lip/unconstrained_layers.py
+++ b/deel/lip/unconstrained_layers.py
@@ -1,0 +1,140 @@
+import tensorflow as tf
+from tensorflow.keras.utils import register_keras_serializable
+
+from .layers import Condensable
+from .utils import _padding_circular
+
+
+@register_keras_serializable("deel-lip", "PadConv2D")
+class PadConv2D(tf.keras.layers.Conv2D, Condensable):
+    def __init__(
+        self,
+        filters,
+        kernel_size,
+        strides=(1, 1),
+        padding="same",
+        data_format=None,
+        dilation_rate=(1, 1),
+        activation=None,
+        use_bias=True,
+        kernel_initializer="glorot_uniform",
+        bias_initializer="zeros",
+        kernel_regularizer=None,
+        bias_regularizer=None,
+        activity_regularizer=None,
+        kernel_constraint=None,
+        bias_constraint=None,
+        **kwargs
+    ):
+        """
+        This class is a Conv2D Layer with parameterized padding.
+        Since Conv2D layer only supports `"same"` and `"valid"` padding, this layer will
+        enable other type of padding, such as `"constant"`, `"symmetric"`, `"reflect"`
+        or `"circular"`.
+
+        Warns:
+            The PadConv2D is not a Lipschitz layer and must not be directly used. This
+            must be used as a base class to create a Lipschitz layer with padding.
+
+        Args:
+            Same args as the body of the original keras.layers.Conv2D, except for
+                padding.
+            padding: one of `"same"`, `"valid"` `"constant"`, `"symmetric"`,
+                `"reflect"` or `"circular"` (case-insensitive).
+        """
+        self.pad = lambda x: x
+        self.old_padding = padding
+        self.internal_input_shape = None
+        if padding.lower() != "same":  # same is directly processed in Conv2D
+            padding = "valid"
+        super(PadConv2D, self).__init__(
+            filters=filters,
+            kernel_size=kernel_size,
+            strides=strides,
+            padding=padding,
+            data_format=data_format,
+            dilation_rate=dilation_rate,
+            activation=activation,
+            use_bias=use_bias,
+            kernel_initializer=kernel_initializer,
+            bias_initializer=bias_initializer,
+            kernel_regularizer=kernel_regularizer,
+            bias_regularizer=bias_regularizer,
+            activity_regularizer=activity_regularizer,
+            kernel_constraint=kernel_constraint,
+            bias_constraint=bias_constraint,
+            **kwargs
+        )
+        self._kwargs = kwargs
+        if self.old_padding.lower() in ["same", "valid"]:
+            self.pad = lambda x: x
+            self.padding_size = [0, 0]
+        if self.old_padding.lower() in ["constant", "reflect", "symmetric"]:
+            self.padding_size = [self.kernel_size[0] // 2, self.kernel_size[1] // 2]
+            paddings = [
+                [0, 0],
+                [self.padding_size[0], self.padding_size[0]],
+                [self.padding_size[1], self.padding_size[1]],
+                [0, 0],
+            ]
+            self.pad = lambda t: tf.pad(t, paddings, self.old_padding)
+        if self.old_padding.lower() == "circular":
+            self.padding_size = [self.kernel_size[0] // 2, self.kernel_size[1] // 2]
+            self.pad = lambda t: _padding_circular(t, self.padding_size)
+
+    def compute_padded_shape(self, input_shape, padding_size):
+        if isinstance(input_shape, tf.TensorShape):
+            internal_input_shape = input_shape.as_list()
+        else:
+            internal_input_shape = list(input_shape)
+
+        first_spatial_dim = 1 if self.data_format == "channels_last" else 2
+        for index, pad in enumerate(padding_size):
+            internal_input_shape[first_spatial_dim + index] += 2 * pad
+        return tf.TensorShape(internal_input_shape)
+
+    def build(self, input_shape):
+        self.internal_input_shape = self.compute_padded_shape(
+            input_shape, self.padding_size
+        )
+        super(PadConv2D, self).build(self.internal_input_shape)
+
+    def compute_output_shape(self, input_shape):
+        return super(PadConv2D, self).compute_output_shape(self.internal_input_shape)
+
+    def call(self, x):
+        x = self.pad(x)
+        return super(PadConv2D, self).call(x)
+
+    def get_config(self):
+        base_config = super(PadConv2D, self).get_config()
+        base_config["padding"] = self.old_padding
+        return base_config
+
+    def condense(self):
+        return
+
+    def vanilla_export(self):
+        self._kwargs["name"] = self.name
+        if self.old_padding.lower() in ["same", "valid"]:
+            layer_type = tf.keras.layers.Conv2D
+        else:
+            layer_type = PadConv2D
+        layer = layer_type(
+            filters=self.filters,
+            kernel_size=self.kernel_size,
+            strides=self.strides,
+            padding=self.old_padding,
+            data_format=self.data_format,
+            dilation_rate=self.dilation_rate,
+            activation=self.activation,
+            use_bias=self.use_bias,
+            kernel_initializer="glorot_uniform",
+            bias_initializer="zeros",
+            **self._kwargs
+        )
+        layer.build(self.input_shape)
+        layer.kernel.assign(self.kernel)
+        if self.use_bias:
+            layer.bias.assign(self.bias)
+        return layer

--- a/tests/test_normalizers.py
+++ b/tests/test_normalizers.py
@@ -1,0 +1,153 @@
+# Copyright IRT Antoine de Saint Exupéry et Université Paul Sabatier Toulouse III - All
+# rights reserved. DEEL is a research program operated by IVADO, IRT Saint Exupéry,
+# CRIAQ and ANITI - https://www.deel.ai/
+# =====================================================================================
+import unittest
+
+import numpy as np
+import tensorflow as tf
+from deel.lip.normalizers import (
+    bjorck_normalization,
+    reshaped_kernel_orthogonalization,
+    spectral_normalization,
+)
+
+np.random.seed(42)
+
+
+class TestSpectralNorm(unittest.TestCase):
+    """Test of spectral normalization (power iteration) on Dense and Conv2D kernels."""
+
+    def test_spectral_normalization(self):
+        # Dense kernel
+        kernel_shape = (15, 32)
+        kernel = np.random.normal(size=kernel_shape).astype("float32")
+        self._test_kernel(kernel)
+
+        # Conv kernel
+        kernel_shape = (5, 5, 64, 32)
+        kernel = np.random.normal(size=kernel_shape).astype("float32")
+        self._test_kernel(kernel)
+
+    def _test_kernel(self, kernel):
+        """Compare max singular value using power iteration and tf.linalg.svd"""
+        sigmas_svd = tf.linalg.svd(
+            np.reshape(kernel, (np.prod(kernel.shape[:-1]), kernel.shape[-1])),
+            full_matrices=False,
+            compute_uv=False,
+        ).numpy()
+        SVmax = np.max(sigmas_svd)
+
+        W_bar, _u, sigma = spectral_normalization(kernel, u=None, eps=1e-6)
+        # Test sigma is close to the one computed with svd first run @ 1e-1
+        np.testing.assert_approx_equal(
+            sigma, SVmax, 1, "test failed with kernel_shape " + str(kernel.shape)
+        )
+
+        W_bar, _u, sigma = spectral_normalization(kernel, u=_u, eps=1e-6)
+        W_bar, _u, sigma = spectral_normalization(kernel, u=_u, eps=1e-6)
+        # Test W_bar is reshaped correctly
+        np.testing.assert_equal(
+            W_bar.shape, (np.prod(kernel.shape[:-1]), kernel.shape[-1])
+        )
+        # Test sigma is close to the one computed with svd second run @ 1e-5
+        np.testing.assert_approx_equal(
+            sigma, SVmax, 3, "test failed with kernel_shape " + str(kernel.shape)
+        )
+        # Test if kernel is normalized by sigma
+        np.testing.assert_allclose(
+            np.reshape(W_bar, kernel.shape), kernel / sigmas_svd[0], 1e-2, 0
+        )
+
+
+class TestBjorckNormalization(unittest.TestCase):
+    """Test of Björck orthogonalization on Dense and Conv2D kernels."""
+
+    def test_bjorck_normalization(self):
+        # Dense kernel
+        kernel_shape = (15, 32)
+        kernel = np.random.normal(size=kernel_shape).astype("float32")
+        self._test_kernel(kernel)
+
+        # Conv kernel
+        kernel_shape = (64, 32)
+        kernel = np.random.normal(size=kernel_shape).astype("float32")
+        self._test_kernel(kernel)
+
+    def _test_kernel(self, kernel):
+        """Compare max singular value using power iteration and tf.linalg.svd"""
+        sigmas_svd = tf.linalg.svd(
+            np.reshape(kernel, (np.prod(kernel.shape[:-1]), kernel.shape[-1])),
+            full_matrices=False,
+            compute_uv=False,
+        ).numpy()
+        SVmax = np.max(sigmas_svd)
+
+        wbar = bjorck_normalization(kernel / SVmax, eps=1e-5)
+        sigmas_wbar_svd = tf.linalg.svd(
+            np.reshape(wbar, (np.prod(wbar.shape[:-1]), wbar.shape[-1])),
+            full_matrices=False,
+            compute_uv=False,
+        ).numpy()
+        # Test sigma is close to the one computed with svd first run @ 1e-1
+        np.testing.assert_allclose(
+            sigmas_wbar_svd, np.ones(sigmas_wbar_svd.shape), 1e-2, 0
+        )
+        # Test W_bar is reshaped correctly
+        np.testing.assert_equal(
+            wbar.shape, (np.prod(kernel.shape[:-1]), kernel.shape[-1])
+        )
+
+        # Test sigma is close to the one computed with svd second run @1e-5
+        wbar = bjorck_normalization(wbar, eps=1e-5)
+        sigmas_wbar_svd = tf.linalg.svd(
+            np.reshape(wbar, (np.prod(wbar.shape[:-1]), wbar.shape[-1])),
+            full_matrices=False,
+            compute_uv=False,
+        ).numpy()
+        np.testing.assert_allclose(
+            sigmas_wbar_svd, np.ones(sigmas_wbar_svd.shape), 1e-4, 0
+        )
+
+
+class TestRKO(unittest.TestCase):
+    """Test of RKO algorithm on Dense and Conv2D kernels."""
+
+    def test_reshaped_kernel_orthogonalization(self):
+        # Dense kernel
+        kernel_shape = (15, 32)
+        kernel = np.random.normal(size=kernel_shape).astype("float32")
+        self._test_kernel(kernel)
+
+        # Conv kernel
+        kernel_shape = (5, 5, 64, 32)
+        kernel = np.random.normal(size=kernel_shape).astype("float32")
+        self._test_kernel(kernel)
+
+    def _test_kernel(self, kernel):
+        """Compare max singular value using power iteration and tf.linalg.svd"""
+        sigmas_svd = tf.linalg.svd(
+            np.reshape(kernel, (np.prod(kernel.shape[:-1]), kernel.shape[-1])),
+            full_matrices=False,
+            compute_uv=False,
+        ).numpy()
+        SVmax = np.max(sigmas_svd)
+
+        W_bar, _, sigma = reshaped_kernel_orthogonalization(
+            kernel, u=None, adjustment_coef=1.0, eps_spectral=1e-5, eps_bjorck=1e-5
+        )
+        # Test W_bar is reshaped correctly
+        np.testing.assert_equal(W_bar.shape, kernel.shape)
+        # Test RKO sigma is close to max(svd)
+        np.testing.assert_approx_equal(
+            sigma, SVmax, 1, "test failed with kernel_shape " + str(kernel.shape)
+        )
+        sigmas_wbar_svd = tf.linalg.svd(
+            np.reshape(W_bar, (np.prod(W_bar.shape[:-1]), W_bar.shape[-1])),
+            full_matrices=False,
+            compute_uv=False,
+        ).numpy()
+        # Test if SVs of W_bar are close to one
+        np.testing.assert_allclose(
+            sigmas_wbar_svd, np.ones(sigmas_wbar_svd.shape), 1e-2, 0
+        )

--- a/tests/test_unconstrained_layers.py
+++ b/tests/test_unconstrained_layers.py
@@ -1,0 +1,192 @@
+import unittest
+
+import numpy as np
+import tensorflow as tf
+from deel.lip.unconstrained_layers import PadConv2D
+from deel.lip.model import vanillaModel
+from deel.lip.utils import _padding_circular
+
+from .test_layers import generate_k_lip_model
+
+
+class TestPadConv2D(unittest.TestCase):
+    def test_PadConv2D(self):
+        """Main test for PadConv2D: tests on padding, predict and vanilla export."""
+
+        all_paddings = ("circular", "constant", "symmetric", "reflect", "same", "valid")
+        layer_params = {
+            "filters": 2,
+            "kernel_size": (3, 3),
+            "use_bias": False,
+            "padding": "valid",
+        }
+        batch_size = 250
+        kernel_input_shapes = [
+            [(3, 3), 2, (5, 5, 1)],
+            [(3, 3), 2, (5, 5, 5)],
+            [(7, 7), 2, (7, 7, 2)],
+            [3, 2, (5, 5, 128)],
+        ]
+
+        for k_shape, filters, input_shape in kernel_input_shapes:
+            layer_params["kernel_size"] = k_shape
+            layer_params["filters"] = filters
+            for pad in ["circular", "constant", "symmetric", "reflect"]:
+                self._test_padding(pad, input_shape, batch_size, k_shape)
+            for pad in all_paddings:
+                self._test_predict(layer_params, pad, input_shape, batch_size)
+            for pad in all_paddings:
+                self._test_vanilla(layer_params, pad, input_shape, batch_size)
+
+    def pad_input(self, x, padding, kernel_size):
+        """Pad an input tensor x with corresponding padding, based on kernel size."""
+        if isinstance(kernel_size, (int, float)):
+            kernel_size = [kernel_size, kernel_size]
+        if padding.lower() in ["same", "valid"]:
+            return x
+        elif padding.lower() in ["constant", "reflect", "symmetric"]:
+            p_vert, p_hor = kernel_size[0] // 2, kernel_size[1] // 2
+            pad_sizes = [[0, 0], [p_vert, p_vert], [p_hor, p_hor], [0, 0]]
+            return tf.pad(x, pad_sizes, padding)
+        elif padding.lower() in ["circular"]:
+            p_vert, p_hor = kernel_size[0] // 2, kernel_size[1] // 2
+            return _padding_circular(x, (p_vert, p_hor))
+
+    def compare(self, x, x_ref, index_x=[], index_x_ref=[]):
+        """Compare a tensor and its padded version, based on index_x and ref."""
+        x_cropped = x[:, index_x[0] : index_x[1], index_x[3] : index_x[4], :][
+            :, :: index_x[2], :: index_x[5], :
+        ]
+        if index_x_ref[0] is None:  # compare with 0
+            np.testing.assert_allclose(x_cropped, np.zeros(x_cropped.shape), 1e-2, 0)
+        else:
+            np.testing.assert_allclose(
+                x_cropped,
+                x_ref[
+                    :,
+                    index_x_ref[0] : index_x_ref[1],
+                    index_x_ref[3] : index_x_ref[4],
+                    :,
+                ][:, :: index_x_ref[2], :: index_x_ref[5], :],
+                1e-2,
+                0,
+            )
+
+    def _test_padding(self, padding_tested, input_shape, batch_size, kernel_size):
+        """Test different padding types: assert values in original and padded tensors"""
+        kernel_size_list = kernel_size
+        if isinstance(kernel_size, (int, float)):
+            kernel_size_list = [kernel_size, kernel_size]
+
+        x = np.random.normal(size=(batch_size,) + input_shape).astype("float32")
+        x_pad = self.pad_input(x, padding_tested, kernel_size)
+        p_vert, p_hor = kernel_size_list[0] // 2, kernel_size_list[1] // 2
+
+        center_x_pad = [p_vert, -p_vert, 1, p_hor, -p_hor, 1, "center"]
+        upper_x_pad = [0, p_vert, 1, p_hor, -p_hor, 1, "upper"]
+        lower_x_pad = [-p_vert, x_pad.shape[1], 1, p_hor, -p_hor, 1, "lower"]
+        left_x_pad = [p_vert, -p_vert, 1, 0, p_hor, 1, "left"]
+        right_x_pad = [p_vert, -p_vert, 1, -p_hor, x_pad.shape[2], 1, "right"]
+        all_x = [0, x.shape[1], 1, 0, x.shape[2], 1]
+        upper_x = [0, p_vert, 1, 0, x.shape[2], 1]
+        upper_x_rev = [0, p_vert, -1, 0, x.shape[2], 1]
+        upper_x_refl = [1, p_vert + 1, -1, 0, x.shape[2], 1]
+        lower_x = [-p_vert, x.shape[1], 1, 0, x.shape[2], 1]
+        lower_x_rev = [-p_vert, x.shape[1], -1, 0, x.shape[2], 1]
+        lower_x_refl = [-p_vert - 1, x.shape[1] - 1, -1, 0, x.shape[2], 1]
+        left_x = [0, x.shape[1], 1, 0, p_hor, 1]
+        left_x_rev = [0, x.shape[1], 1, 0, p_hor, -1]
+        left_x_refl = [0, x.shape[1], 1, 1, p_hor + 1, -1]
+        right_x = [0, x.shape[1], 1, -p_hor, x.shape[2], 1]
+        right_x_rev = [0, x.shape[1], 1, -p_hor, x.shape[2], -1]
+        right_x_refl = [0, x.shape[1], 1, -p_hor - 1, x.shape[2] - 1, -1]
+        zero_pad = [None, None, None, None]
+        pad_tests = [
+            {
+                "circular": [center_x_pad, all_x],
+                "constant": [center_x_pad, all_x],
+                "symmetric": [center_x_pad, all_x],
+                "reflect": [center_x_pad, all_x],
+            },
+            {
+                "circular": [upper_x_pad, lower_x],
+                "constant": [upper_x_pad, zero_pad],
+                "symmetric": [upper_x_pad, upper_x_rev],
+                "reflect": [upper_x_pad, upper_x_refl],
+            },
+            {
+                "circular": [lower_x_pad, upper_x],
+                "constant": [lower_x_pad, zero_pad],
+                "symmetric": [lower_x_pad, lower_x_rev],
+                "reflect": [lower_x_pad, lower_x_refl],
+            },
+            {
+                "circular": [left_x_pad, right_x],
+                "constant": [left_x_pad, zero_pad],
+                "symmetric": [left_x_pad, left_x_rev],
+                "reflect": [left_x_pad, left_x_refl],
+            },
+            {
+                "circular": [right_x_pad, left_x],
+                "constant": [right_x_pad, zero_pad],
+                "symmetric": [right_x_pad, right_x_rev],
+                "reflect": [right_x_pad, right_x_refl],
+            },
+        ]
+
+        for test_pad in pad_tests:
+            self.compare(
+                x_pad,
+                x,
+                index_x=test_pad[padding_tested][0],
+                index_x_ref=test_pad[padding_tested][1],
+            )
+
+    def _test_predict(self, layer_params, padding_tested, input_shape, batch_size):
+        """Compare predictions between pad+Conv2D and PadConv2D layers."""
+        x = np.random.normal(size=(batch_size,) + input_shape).astype("float32")
+        x_pad = self.pad_input(x, padding_tested, layer_params["kernel_size"])
+        layer_params_ref = layer_params.copy()
+        if padding_tested.lower() == "same":
+            layer_params_ref["padding"] = "same"
+
+        model_ref = generate_k_lip_model(
+            layer_type=tf.keras.layers.Conv2D,
+            layer_params=layer_params_ref,
+            input_shape=x_pad.shape[1:],
+            k=1.0,
+        )
+        y_ref = model_ref.predict(x_pad)
+
+        layer_params_pad = layer_params.copy()
+        layer_params_pad["padding"] = padding_tested
+        model = generate_k_lip_model(
+            layer_type=PadConv2D,
+            layer_params=layer_params_pad,
+            input_shape=input_shape,
+            k=1.0,
+        )
+
+        model.layers[1].kernel.assign(model_ref.layers[1].kernel)
+        if model.layers[1].use_bias:
+            model.layers[1].bias.assign(model_ref.layers[1].bias)
+        y = model.predict(x)
+
+        np.testing.assert_allclose(y_ref, y, 1e-2, 0)
+
+    def _test_vanilla(self, layer_params, padding_tested, input_shape, batch_size):
+        """Compare predictions between PadConv2D and its vanilla export."""
+        x = np.random.normal(size=(batch_size,) + input_shape).astype("float32")
+        layer_params_pad = layer_params.copy()
+        layer_params_pad["padding"] = padding_tested
+        model = generate_k_lip_model(
+            layer_type=PadConv2D,
+            layer_params=layer_params_pad,
+            input_shape=input_shape,
+            k=1.0,
+        )
+        y = model.predict(x)
+
+        model_v = vanillaModel(model)
+        y_v = model_v.predict(x)
+        np.testing.assert_allclose(y_v, y, 1e-2, 0)


### PR DESCRIPTION
This PR introduces a new `PadConv2D` layer that is the combination of a padding operation and a Conv2D layer. Different padding types can be set:

- "valid": corresponds to the standard "valid" convolution in Keras Conv2D (i.e. no padding). The output shape is smaller than the input shape.
- "same": corresponds to the standard zero padding in Keras Conv2D. The output shape is equal to the input shape.
- "constant": equivalent to "same", i.e. zero padding.
- "symmetric"/"reflect": mirror padding as in `tf.pad()`. The output shape is equal to the input shape.
- "circular": circular padding. The output shape is equal to the input shape.

Moreover, some bugs are fixed and unit tests are added.