### PR TITLE
Lorth regularizer

### DIFF
--- a/deel/lip/__init__.py
+++ b/deel/lip/__init__.py
@@ -12,4 +12,5 @@ from . import losses
 from . import metrics
 from .model import Sequential, Model, vanillaModel
 from . import normalizers
+from . import regularizers
 from . import utils

--- a/deel/lip/regularizers.py
+++ b/deel/lip/regularizers.py
@@ -1,0 +1,153 @@
+# -*- coding: utf-8 -*-
+# Copyright IRT Antoine de Saint Exupéry et Université Paul Sabatier Toulouse III - All
+# rights reserved. DEEL is a research program operated by IVADO, IRT Saint Exupéry,
+# CRIAQ and ANITI - https://www.deel.ai/
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# Copyright IRT Antoine de Saint Exupéry et Université Paul Sabatier Toulouse III - All
+# rights reserved. DEEL is a research program operated by IVADO, IRT Saint Exupéry,
+# CRIAQ and ANITI - https://www.deel.ai/
+# =====================================================================================
+
+import warnings
+from abc import ABC, abstractmethod
+
+import tensorflow as tf
+from tensorflow.keras.regularizers import Regularizer
+from tensorflow.keras.utils import register_keras_serializable
+
+
+class Lorth(ABC):
+    def __init__(self, dim, kernel_shape=None, stride=1, conv_transpose=False) -> None:
+        """
+        Base class for Lorth regularization. Not meant to be used standalone.
+
+        Args:
+            dim (int): the rank of the convolution, e.g. "2" for 2D convolution.
+            kernel_shape: the shape of the kernel.
+            stride (int): stride used in the associated convolution
+            conv_transpose (bool): whether the kernel is from a transposed convolution.
+        """
+        super(Lorth, self).__init__()
+        self.dim = dim
+        self.stride = stride
+        self.conv_transpose = conv_transpose
+        self.set_kernel_shape(kernel_shape)
+
+    def _get_kernel_shape(self):
+        """Return the kernel size, the number of input channels and output channels"""
+        return [self.kernel_shape[i] for i in (0, -2, -1)]
+
+    def _compute_delta(self):
+        """delta is positive in CO case, zero in RO case."""
+        _, C, M = self._get_kernel_shape()
+        if not self.conv_transpose:
+            delta = M - (self.stride**self.dim) * C
+        else:
+            delta = C - (self.stride**self.dim) * M
+        return max(0, delta)
+
+    def _check_if_orthconv_exists(self):
+        R, C, M = self._get_kernel_shape()
+        msg = "Impossible {} configuration for orthogonal convolution."
+        if C * self.stride**self.dim >= M:  # RO case
+            if M > C * (R**self.dim):
+                raise RuntimeError(msg.format("RO"))
+        else:  # CO case
+            if self.stride > R:
+                raise RuntimeError(msg.format("CO"))
+        if C * (self.stride**self.dim) == M:  # square case
+            warnings.warn(
+                "LorthRegularizer: warning configuration C*S^2=M is hard to optimize."
+            )
+
+    def set_kernel_shape(self, shape):
+        if shape is None:
+            self.kernel_shape, self.padding, self.delta = None, None, None
+            return
+
+        R = shape[0]
+        self.kernel_shape = shape
+        self.padding = ((R - 1) // self.stride) * self.stride
+        self.delta = self._compute_delta()
+
+        # Assertions on kernel shape and existence of orthogonal convolution
+        assert R & 1, "Lorth regularizer requires odd kernels. Receives " + str(R)
+        self._check_if_orthconv_exists()
+
+    @abstractmethod
+    def _compute_conv_kk(self, w):
+        raise NotImplementedError()
+
+    @abstractmethod
+    def _compute_target(self, w, output_shape):
+        raise NotImplementedError()
+
+    def compute_lorth(self, w):
+        output = self._compute_conv_kk(w)
+        target = self._compute_target(w, output.shape)
+        return tf.reduce_sum(tf.square(output - target)) - self.delta
+
+
+class Lorth2D(Lorth):
+    def __init__(self, kernel_shape=None, stride=1, conv_transpose=False) -> None:
+        """
+        Lorth computation for 2D convolutions. Although this class allows to compute
+        the regularization term, it cannot be used as it is in a layer.
+
+        Args:
+            kernel_shape: the shape of the kernel.
+            stride (int): stride used in the associated convolution
+            conv_transpose (bool): whether the kernel is from a transposed convolution.
+        """
+        dim = 2
+        super(Lorth2D, self).__init__(dim, kernel_shape, stride, conv_transpose)
+
+    def _compute_conv_kk(self, w):
+        w_reshape = tf.transpose(w, perm=[3, 0, 1, 2])
+        w_padded = tf.pad(
+            w_reshape,
+            paddings=[
+                [0, 0],
+                [self.padding, self.padding],
+                [self.padding, self.padding],
+                [0, 0],
+            ],
+        )
+        return tf.nn.conv2d(w_padded, w, self.stride, padding="VALID")
+
+    def _compute_target(self, w, convKxK_shape):
+        C_out = w.shape[-1]
+        outm3 = convKxK_shape[-3]
+        outm2 = convKxK_shape[-2]
+        ct = tf.cast(tf.math.floor(outm2 / 2), dtype=tf.int32)
+
+        target_zeros = tf.zeros((outm3 * outm2 - 1, C_out, C_out))
+        target = tf.concat(
+            [
+                target_zeros[: ct * outm2 + ct],
+                tf.expand_dims(tf.eye(C_out), axis=0),
+                target_zeros[ct * outm2 + ct :],
+            ],
+            axis=0,
+        )
+
+        target = tf.reshape(target, (outm3, outm2, C_out, C_out))
+        target = tf.transpose(target, [2, 0, 1, 3])
+        return target

--- a/doc/source/deel.lip.regularizers.rst
+++ b/doc/source/deel.lip.regularizers.rst
@@ -1,0 +1,8 @@
+deel.lip.regularizers module
+============================
+
+.. automodule:: deel.lip.regularizers
+   :exclude-members: Lorth, Lorth2D
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/source/deel.lip.rst
+++ b/doc/source/deel.lip.rst
@@ -16,6 +16,7 @@ Submodules
    deel.lip.metrics
    deel.lip.model
    deel.lip.normalizers
+   deel.lip.regularizers
    deel.lip.unconstrained_layers
    deel.lip.utils
 

--- a/tests/test_regularizers.py
+++ b/tests/test_regularizers.py
@@ -1,0 +1,126 @@
+# -*- coding: utf-8 -*-
+# Copyright IRT Antoine de Saint Exupéry et Université Paul Sabatier Toulouse III - All
+# rights reserved. DEEL is a research program operated by IVADO, IRT Saint Exupéry,
+# CRIAQ and ANITI - https://www.deel.ai/
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# Copyright IRT Antoine de Saint Exupéry et Université Paul Sabatier Toulouse III - All
+# rights reserved. DEEL is a research program operated by IVADO, IRT Saint Exupéry,
+# CRIAQ and ANITI - https://www.deel.ai/
+# =====================================================================================
+
+from unittest import TestCase
+
+import numpy as np
+import tensorflow as tf
+from deel.lip.regularizers import Lorth2D, LorthRegularizer
+
+
+class TestLorth2D(TestCase):
+    """Tests on Lorth2D class"""
+
+    def test_set_kernel_shape(self):
+        """Assert that set_kernel_shape() correctly sets parameters."""
+        # RO case
+        lorth = Lorth2D()
+        self.assertIsNone(lorth.kernel_shape)
+        self.assertIsNone(lorth.delta)
+        self.assertIsNone(lorth.padding)
+
+        kernel_shape = (5, 5, 32, 64)
+        lorth.set_kernel_shape(kernel_shape)
+        self.assertEqual(lorth.kernel_shape, kernel_shape)
+        self.assertEqual(lorth.delta, 32)
+        self.assertEqual(lorth.padding, 4)
+
+        # CO case
+        lorth = Lorth2D(stride=3)
+        kernel_shape = (5, 5, 8, 70)
+        lorth.set_kernel_shape(kernel_shape)
+
+        self.assertEqual(lorth.kernel_shape, kernel_shape)
+        self.assertEqual(lorth.delta, 0)  # zero, because CO case
+        self.assertEqual(lorth.padding, 3)
+
+    def test_existence_orthogonal_conv(self):
+        """Assert that Error and Warning are correctly raised when checking existence
+        of the orthogonal convolution."""
+
+        # RO case
+        with self.assertRaisesRegex(RuntimeError, "Impossible RO"):
+            kernel_shape = (3, 3, 32, 289)
+            Lorth2D(kernel_shape, stride=4)
+
+        # CO case
+        with self.assertRaisesRegex(RuntimeError, "Impossible CO"):
+            kernel_shape = (3, 3, 8, 129)
+            Lorth2D(kernel_shape, stride=4)
+
+        # square case (RO=CO)
+        with self.assertWarnsRegex(Warning, "hard to optimize"):
+            kernel_shape = (3, 3, 32, 32)
+            Lorth2D(kernel_shape, stride=1)
+
+    def test_compute_lorth(self):
+        """Assert Lorth2D computation on an identity kernel => must return 0"""
+
+        def _identity_kernel(kernel_size, channels):
+            assert kernel_size & 1
+            kernel_shape = (kernel_size, kernel_size, channels, channels)
+            w = np.zeros(kernel_shape, dtype=np.float32)
+            for i in range(channels):
+                w[kernel_size // 2, kernel_size // 2, i, i] = 1
+            return tf.constant(w)
+
+        kernel_size = (np.random.randint(1, 10) * 2) + 1
+        channels = np.random.randint(1, 100)
+        w = _identity_kernel(kernel_size, channels)
+
+        lorth = Lorth2D(w.shape)
+        loss = lorth.compute_lorth(w)
+        self.assertAlmostEqual(loss.numpy(), 0)
+
+
+class TestLorthRegularizer(TestCase):
+    """Tests on LorthRegularizer"""
+
+    def test_init(self):
+        """Check initialization from scratch and from config."""
+
+        kshape1 = (3, 3, 16, 32)
+        kshape2 = (5, 5, 16, 8)
+        stride = np.random.randint(1, 4)
+        lambda_lorth = np.random.normal()
+        regul = LorthRegularizer(kshape1, stride, lambda_lorth)
+
+        self.assertEqual(regul.lorth.kernel_shape, kshape1)
+
+        # Set new shape and get config
+        regul.set_kernel_shape(kshape2)
+        config = regul.get_config()
+        new_regul = LorthRegularizer.from_config(config)
+
+        self.assertEqual(new_regul.lorth.kernel_shape, kshape2)
+        self.assertEqual(new_regul.stride, stride)
+        self.assertEqual(new_regul.lambda_lorth, lambda_lorth)
+
+    def test_1D_not_supported(self):
+        """Assert that 1D convolutions are not supported."""
+        with self.assertRaisesRegex(NotImplementedError, "Only 2D convolutions"):
+            LorthRegularizer(dim=1)


### PR DESCRIPTION
A regularizer `LorthRegularizer` to enforce orthogonal convolution (based on Lorth) is introduced. For now, only 2D convolutions are supported.