### PR TITLE
SpectralConv2DTranspose

### DIFF
--- a/deel/lip/layers.py
+++ b/deel/lip/layers.py
@@ -150,6 +150,16 @@ class Condensable(abc.ABC):
         pass
 
 
+def _check_RKO_params(eps_spectral, eps_bjorck, beta_bjorck):
+    """Assert that the RKO hyper-parameters are supported values."""
+    if eps_spectral <= 0:
+        raise ValueError("eps_spectral has to be > 0")
+    if (eps_bjorck is not None) and (eps_bjorck <= 0.0):
+        raise ValueError("eps_bjorck must be > 0")
+    if (beta_bjorck is not None) and not (0.0 < beta_bjorck <= 0.5):
+        raise ValueError("beta_bjorck must be in ]0, 0.5]")
+
+
 @register_keras_serializable("deel-lip", "SpectralDense")
 class SpectralDense(keraslayers.Dense, LipschitzLayer, Condensable):
     def __init__(
@@ -226,21 +236,14 @@ class SpectralDense(keraslayers.Dense, LipschitzLayer, Condensable):
         )
         self._kwargs = kwargs
         self.set_klip_factor(k_coef_lip)
+        _check_RKO_params(eps_spectral, eps_bjorck, beta_bjorck)
         self.eps_spectral = eps_spectral
         self.beta_bjorck = beta_bjorck
-        if (self.beta_bjorck is not None) and (
-            not ((self.beta_bjorck <= 0.5) and (self.beta_bjorck > 0.0))
-        ):
-            raise RuntimeError("beta_bjorck must be in ]0, 0.5]")
         self.eps_bjorck = eps_bjorck
-        if (self.eps_bjorck is not None) and (not self.eps_bjorck > 0.0):
-            raise RuntimeError("eps_bjorck must be in > 0")
         self.u = None
         self.sig = None
         self.wbar = None
         self.built = False
-        if self.eps_spectral < 0:
-            raise RuntimeError("eps_spectral has to be > 0")
 
     def build(self, input_shape):
         super(SpectralDense, self).build(input_shape)
@@ -446,17 +449,10 @@ class SpectralConv2D(keraslayers.Conv2D, LipschitzLayer, Condensable):
         self.u = None
         self.sig = None
         self.wbar = None
+        _check_RKO_params(eps_spectral, eps_bjorck, beta_bjorck)
         self.eps_spectral = eps_spectral
-        self.beta_bjorck = beta_bjorck
-        if (self.beta_bjorck is not None) and (
-            not ((self.beta_bjorck <= 0.5) and (self.beta_bjorck > 0.0))
-        ):
-            raise RuntimeError("beta_bjorck must be in ]0, 0.5]")
         self.eps_bjorck = eps_bjorck
-        if (self.eps_bjorck is not None) and (not self.eps_bjorck > 0.0):
-            raise RuntimeError("eps_bjorck must be in > 0")
-        if self.eps_spectral < 0:
-            raise RuntimeError("eps_spectral has to be > 0")
+        self.beta_bjorck = beta_bjorck
 
     def build(self, input_shape):
         super(SpectralConv2D, self).build(input_shape)

--- a/deel/lip/layers.py
+++ b/deel/lip/layers.py
@@ -420,9 +420,9 @@ class SpectralConv2D(keraslayers.Conv2D, LipschitzLayer, Condensable):
             or (dilation_rate == [1, 1])
             or (dilation_rate == 1)
         ):
-            raise RuntimeError("NormalizedConv does not support dilation rate")
+            raise RuntimeError("SpectralConv2D does not support dilation rate")
         if padding != "same":
-            raise RuntimeError("NormalizedConv only support padding='same'")
+            raise RuntimeError("SpectralConv2D only supports padding='same'")
         super(SpectralConv2D, self).__init__(
             filters=filters,
             kernel_size=kernel_size,
@@ -716,15 +716,15 @@ class FrobeniusConv2D(keraslayers.Conv2D, LipschitzLayer, Condensable):
         **kwargs
     ):
         if not ((strides == (1, 1)) or (strides == [1, 1]) or (strides == 1)):
-            raise RuntimeError("NormalizedConv does not support strides")
+            raise RuntimeError("FrobeniusConv2D does not support strides")
         if not (
             (dilation_rate == (1, 1))
             or (dilation_rate == [1, 1])
             or (dilation_rate == 1)
         ):
-            raise RuntimeError("NormalizedConv does not support dilation rate")
+            raise RuntimeError("FrobeniusConv2D does not support dilation rate")
         if padding != "same":
-            raise RuntimeError("NormalizedConv only support padding='same'")
+            raise RuntimeError("FrobeniusConv2D only supports padding='same'")
         if not (
             (kernel_constraint is None)
             or isinstance(kernel_constraint, SpectralConstraint)
@@ -855,7 +855,7 @@ class ScaledAveragePooling2D(keraslayers.AveragePooling2D, LipschitzLayer):
         if not ((strides == pool_size) or (strides is None)):
             raise RuntimeError("stride must be equal to pool_size")
         if padding != "valid":
-            raise RuntimeError("ScaledAveragePooling2D only support padding='valid'")
+            raise RuntimeError("ScaledAveragePooling2D only supports padding='valid'")
         super(ScaledAveragePooling2D, self).__init__(
             pool_size=pool_size,
             strides=pool_size,
@@ -943,7 +943,7 @@ class ScaledL2NormPooling2D(keraslayers.AveragePooling2D, LipschitzLayer):
         if not ((strides == pool_size) or (strides is None)):
             raise RuntimeError("stride must be equal to pool_size")
         if padding != "valid":
-            raise RuntimeError("NormalizedConv only support padding='valid'")
+            raise RuntimeError("ScaledL2NormPooling2D only supports padding='valid'")
         if eps_grad_sqrt < 0.0:
             raise RuntimeError("eps_grad_sqrt must be positive")
         super(ScaledL2NormPooling2D, self).__init__(

--- a/tests/test_condense.py
+++ b/tests/test_condense.py
@@ -11,6 +11,7 @@ from deel.lip.model import Sequential, Model
 from deel.lip.layers import (
     SpectralDense,
     SpectralConv2D,
+    SpectralConv2DTranspose,
     FrobeniusDense,
     FrobeniusConv2D,
     ScaledL2NormPooling2D,
@@ -42,6 +43,7 @@ class MyTestCase(unittest.TestCase):
                 SpectralConv2D(2, (3, 3)),
                 ScaledL2NormPooling2D((2, 2)),
                 FrobeniusConv2D(2, (3, 3)),
+                SpectralConv2DTranspose(5, 3),
                 Flatten(),
                 Dense(4),
                 SpectralDense(4),
@@ -57,6 +59,7 @@ class MyTestCase(unittest.TestCase):
         x = SpectralConv2D(2, (3, 3), k_coef_lip=2.0)(inp)
         x = ScaledL2NormPooling2D((2, 2), k_coef_lip=2.0)(x)
         x = FrobeniusConv2D(2, (3, 3), k_coef_lip=2.0)(x)
+        x = SpectralConv2DTranspose(5, 3, k_coef_lip=2.0)(x)
         x = Flatten()(x)
         x = Dense(4)(x)
         x = SpectralDense(4, k_coef_lip=2.0)(x)

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -434,7 +434,7 @@ class Test(TestCase):
         num_items = 10000
         y_true = tf.one_hot(np.random.randint(num_classes, size=num_items), num_classes)
         y_true = process_labels_for_multi_gpu(y_true)
-        y_pred = tf.random.normal((num_items, num_classes))
+        y_pred = tf.random.normal((num_items, num_classes), seed=17)
 
         # Compare full batch loss and mini-batches loss
         for loss in losses:


### PR DESCRIPTION
The `SpectralConv2DTranspose` layer is a new Lipschitz layer equivalent to the tf.keras `Conv2DTranspose`. 
Note that some arguments must be set to a specific value to be supported:
- `padding` must be `same`
- `dilation_rate` must be `(1, 1)`
- `output_padding` must be `None`

Like the SpectralConv2D layer, the kernel is normalized using the spectral normalization, then orthogonalized with Björck algorithm.