### PR TITLE
Introduce new losses (part 1)

### DIFF
--- a/deel/lip/callbacks.py
+++ b/deel/lip/callbacks.py
@@ -197,3 +197,32 @@ class LossParamScheduler(Callback):
             "step": self.step,
             "param_name": self.param_name,
         }
+
+
+class LossParamLog(Callback):
+    def __init__(self, param_name, rate=1):
+        """
+        Logger to print values of a loss parameter at each epoch.
+
+        Args:
+            param_name (str): name of the parameter of the loss to log.
+            rate (int): logging rate (in epochs)
+        """
+        self.param_name = param_name
+        self.rate = rate
+
+    def on_epoch_end(self, epoch: int, logs=None):
+        if epoch % self.rate == 0:
+            tf.print(
+                "\n",
+                self.model.loss.name,
+                self.param_name,
+                self.model.loss.__getattribute__(self.param_name),
+            )
+        super(LossParamLog, self).on_train_batch_end(epoch, logs)
+
+    def get_config(self):
+        return {
+            "param_name": self.param_name,
+            "rate": self.rate,
+        }

--- a/deel/lip/callbacks.py
+++ b/deel/lip/callbacks.py
@@ -10,7 +10,7 @@ from typing import Optional, Dict, Iterable
 
 import tensorflow as tf
 from tensorflow.keras.callbacks import Callback
-
+import numpy as np
 from .layers import Condensable
 
 
@@ -164,3 +164,36 @@ class MonitorCallback(Callback):
         }
         base_config = super(MonitorCallback, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
+
+
+class LossParamScheduler(Callback):
+    def __init__(self, param_name, fp, xp, step=0):
+        """
+        Scheduler to modify a loss parameter during training. It uses a linear
+        interpolation (defined by fp and xp) depending on the optimization step.
+
+        Args:
+            param_name (str): name of the parameter of the loss to tune. Must be a
+                tf.Variable.
+            fp (list): values of the loss parameter as steps given by the xp.
+            xp (list): step where the parameter equals fp.
+            step: step value, for serialization/deserialization purposes.
+        """
+        self.xp = xp
+        self.fp = fp
+        self.step = step
+        self.param_name = param_name
+
+    def on_train_batch_begin(self, batch: int, logs=None):
+        new_value = np.interp(self.step, self.xp, self.fp)
+        self.model.loss.__getattribute__(self.param_name).assign(new_value)
+        self.step += 1
+        super(LossParamScheduler, self).on_train_batch_end(batch, logs)
+
+    def get_config(self):
+        return {
+            "xp": self.xp,
+            "fp": self.fp,
+            "step": self.step,
+            "param_name": self.param_name,
+        }

--- a/deel/lip/losses.py
+++ b/deel/lip/losses.py
@@ -274,10 +274,13 @@ class MulticlassKR(Loss):
 def multiclass_hinge(y_true, y_pred, min_margin):
     """Compute the multi-class hinge margin loss.
 
+    `y_true` and `y_pred` must be of shape (batch_size, # classes).
     Note that `y_true` should be one-hot encoded or pre-processed with the
     :func:`deel.lip.utils.process_labels_for_multi_gpu()` function.
 
     Args:
+        y_true: tensor of true targets of shape (batch_size, # classes)
+        y_pred: tensor of predicted targets of shape (batch_size, # classes)
         min_margin: positive float, margin to enforce.
 
     Returns:
@@ -288,10 +291,7 @@ def multiclass_hinge(y_true, y_pred, min_margin):
     # compute the elementwise hinge term
     hinge = tf.nn.relu(min_margin / 2.0 - sign * y_pred)
     # reweight positive elements
-    if (len(tf.shape(y_pred)) == 2) and (tf.shape(y_pred)[-1] != 1):
-        factor = y_true.shape[-1] - 1.0
-    else:
-        factor = 1.0
+    factor = y_pred.shape[-1] - 1.0
     hinge = tf.where(sign > 0, hinge * factor, hinge)
     return tf.reduce_mean(hinge, axis=-1)
 

--- a/deel/lip/losses.py
+++ b/deel/lip/losses.py
@@ -144,8 +144,8 @@ class HKR(Loss):
             name: passed to tf.keras.Loss constructor
 
         """
-        self.alpha = alpha
-        self.min_margin = min_margin
+        self.alpha = tf.Variable(alpha, dtype=tf.float32)
+        self.min_margin = tf.Variable(min_margin, dtype=tf.float32)
         self.multi_gpu = multi_gpu
         self.KRloss = KR(multi_gpu=multi_gpu)
         super(HKR, self).__init__(reduction=reduction, name=name)
@@ -163,8 +163,8 @@ class HKR(Loss):
 
     def get_config(self):
         config = {
-            "alpha": self.alpha,
-            "min_margin": self.min_margin,
+            "alpha": self.alpha.numpy(),
+            "min_margin": self.min_margin.numpy(),
             "multi_gpu": self.multi_gpu,
         }
         base_config = super(HKR, self).get_config()
@@ -215,7 +215,7 @@ class HingeMargin(Loss):
             name: passed to tf.keras.Loss constructor
 
         """
-        self.min_margin = min_margin
+        self.min_margin = tf.Variable(min_margin, dtype=tf.float32)
         super(HingeMargin, self).__init__(reduction=reduction, name=name)
 
     @tf.function
@@ -224,7 +224,7 @@ class HingeMargin(Loss):
 
     def get_config(self):
         config = {
-            "min_margin": self.min_margin,
+            "min_margin": self.min_margin.numpy(),
         }
         base_config = super(HingeMargin, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
@@ -315,7 +315,7 @@ class MulticlassHinge(Loss):
             name: passed to tf.keras.Loss constructor
 
         """
-        self.min_margin = min_margin
+        self.min_margin = tf.Variable(min_margin, dtype=tf.float32)
         super(MulticlassHinge, self).__init__(reduction=reduction, name=name)
 
     @tf.function
@@ -324,7 +324,7 @@ class MulticlassHinge(Loss):
 
     def get_config(self):
         config = {
-            "min_margin": self.min_margin,
+            "min_margin": self.min_margin.numpy(),
         }
         base_config = super(MulticlassHinge, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
@@ -359,8 +359,8 @@ class MulticlassHKR(Loss):
             name: passed to tf.keras.Loss constructor
 
         """
-        self.alpha = alpha
-        self.min_margin = min_margin
+        self.alpha = tf.Variable(alpha, dtype=tf.float32)
+        self.min_margin = tf.Variable(min_margin, dtype=tf.float32)
         self.multi_gpu = multi_gpu
         self.KRloss = MulticlassKR(multi_gpu=multi_gpu, name=name)
         super(MulticlassHKR, self).__init__(reduction=reduction, name=name)
@@ -378,8 +378,8 @@ class MulticlassHKR(Loss):
 
     def get_config(self):
         config = {
-            "alpha": self.alpha,
-            "min_margin": self.min_margin,
+            "alpha": self.alpha.numpy(),
+            "min_margin": self.min_margin.numpy(),
             "multi_gpu": self.multi_gpu,
         }
         base_config = super(MulticlassHKR, self).get_config()
@@ -402,7 +402,7 @@ class MultiMargin(Loss):
             name: passed to tf.keras.Loss constructor
 
         """
-        self.min_margin = min_margin
+        self.min_margin = tf.Variable(min_margin, dtype=tf.float32)
         super(MultiMargin, self).__init__(reduction=reduction, name=name)
 
     @tf.function
@@ -420,7 +420,7 @@ class MultiMargin(Loss):
 
     def get_config(self):
         config = {
-            "min_margin": self.min_margin,
+            "min_margin": self.min_margin.numpy(),
         }
         base_config = super(MultiMargin, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))

--- a/deel/lip/losses.py
+++ b/deel/lip/losses.py
@@ -200,7 +200,7 @@ class HingeMargin(Loss):
     def call(self, y_true, y_pred):
         sign = tf.where(y_true > 0, 1, -1)
         sign = tf.cast(sign, y_pred.dtype)
-        hinge = tf.nn.relu(self.min_margin - sign * y_pred)
+        hinge = tf.nn.relu(self.min_margin / 2.0 - sign * y_pred)
         # In binary case (`y_true` of shape (batch_size, 1)), `tf.reduce_mean(axis=-1)`
         # behaves like `tf.squeeze` to return element-wise loss of shape (batch_size, ).
         return tf.reduce_mean(hinge, axis=-1)
@@ -281,7 +281,7 @@ class MulticlassHinge(Loss):
         sign = tf.where(y_true > 0, 1, -1)
         sign = tf.cast(sign, y_pred.dtype)
         # compute the elementwise hinge term
-        hinge = tf.nn.relu(self.min_margin - sign * y_pred)
+        hinge = tf.nn.relu(self.min_margin / 2.0 - sign * y_pred)
         # reweight positive elements
         if (len(tf.shape(y_pred)) == 2) and (tf.shape(y_pred)[-1] != 1):
             factor = y_true.shape[-1] - 1.0

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -81,7 +81,7 @@ class Test(TestCase):
         check_serialization(1, loss)
 
     def test_hinge_margin_loss(self):
-        loss = HingeMargin(1.0)
+        loss = HingeMargin(2.0)
         y_true = tf.convert_to_tensor([1.0, 1.0, 1.0, 0.0, 0.0, 0.0])
         y_pred = tf.convert_to_tensor([0.5, 1.5, -0.5, -0.5, -1.5, 0.5])
         loss_val = loss(y_true, y_pred).numpy()
@@ -125,8 +125,8 @@ class Test(TestCase):
         check_serialization(1, multiclass_kr)
 
     def test_hinge_multiclass_loss(self):
-        multiclass_hinge = MulticlassHinge(1.0)
-        hinge = HingeMargin(1.0)
+        multiclass_hinge = MulticlassHinge(2.0)
+        hinge = HingeMargin(2.0)
         y_true = tf.convert_to_tensor([1.0, 1.0, 1.0, 0.0, 0.0, 0.0])
         y_pred = tf.convert_to_tensor([0.5, 1.5, -0.5, -0.5, -1.5, 0.5])
         l_single = hinge(y_true, y_pred).numpy()
@@ -167,7 +167,7 @@ class Test(TestCase):
         check_serialization(1, multiclass_hinge)
 
     def test_hkr_multiclass_loss(self):
-        multiclass_hkr = MulticlassHKR(5.0, 1.0)
+        multiclass_hkr = MulticlassHKR(5.0, 2.0)
         y_true = tf.one_hot([0, 0, 0, 1, 1, 2], 3)
         y_pred = np.float32(
             [
@@ -251,8 +251,8 @@ class Test(TestCase):
 
         losses = (
             KR(reduction="none"),
-            HingeMargin(0.7, reduction="none"),
-            HKR(alpha=2.5, reduction="none"),
+            HingeMargin(0.7 * 2.0, reduction="none"),
+            HKR(alpha=2.5, min_margin=2.0, reduction="none"),
         )
 
         expected_loss_values = (
@@ -293,9 +293,9 @@ class Test(TestCase):
         )
         losses = (
             MulticlassKR(reduction="none"),
-            MulticlassHinge(reduction="none"),
+            MulticlassHinge(min_margin=2.0, reduction="none"),
             MultiMargin(0.7, reduction="none"),
-            MulticlassHKR(alpha=2.5, min_margin=0.5, reduction="none"),
+            MulticlassHKR(alpha=2.5, min_margin=1.0, reduction="none"),
             CategoricalHinge(1.1, reduction="none"),
             TauCategoricalCrossentropy(2.0, reduction="none"),
         )
@@ -346,8 +346,8 @@ class Test(TestCase):
         reduction = "sum"
         losses = (
             KR(multi_gpu=True, reduction=reduction),
-            HingeMargin(0.7, reduction=reduction),
-            HKR(alpha=2.5, multi_gpu=True, reduction=reduction),
+            HingeMargin(0.7 * 2.0, reduction=reduction),
+            HKR(alpha=2.5, min_margin=2.0, multi_gpu=True, reduction=reduction),
         )
 
         expected_loss_values = (9.2, 2.2, 0.3)
@@ -434,10 +434,10 @@ class Test(TestCase):
         reduction = "sum"
         losses = (
             MulticlassKR(multi_gpu=True, reduction=reduction),
-            MulticlassHinge(reduction=reduction),
+            MulticlassHinge(min_margin=2.0, reduction=reduction),
             MultiMargin(0.7, reduction=reduction),
             MulticlassHKR(
-                alpha=2.5, min_margin=0.5, multi_gpu=True, reduction=reduction
+                alpha=2.5, min_margin=1.0, multi_gpu=True, reduction=reduction
             ),
         )
 

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -126,30 +126,7 @@ class Test(TestCase):
 
     def test_hinge_multiclass_loss(self):
         multiclass_hinge = MulticlassHinge(2.0)
-        hinge = HingeMargin(2.0)
-        y_true = binary_tf_data([1.0, 1.0, 1.0, 0.0, 0.0, 0.0])
-        y_pred = binary_tf_data([0.5, 1.5, -0.5, -0.5, -1.5, 0.5])
-        l_single = hinge(y_true, y_pred).numpy()
-        l_multi = multiclass_hinge(y_true, y_pred).numpy()
-        self.assertEqual(l_single, np.float32(4 / 6), "Hinge loss must be equal to 4/6")
-        self.assertEqual(
-            l_single,
-            l_multi,
-            "hinge multiclass must yield the same "
-            "results when given a single class "
-            "vector",
-        )
-        y_true = tf.expand_dims(y_true, -1)
-        y_pred = tf.expand_dims(y_pred, -1)
-        l_single = hinge(y_true, y_pred).numpy()
-        l_multi = multiclass_hinge(y_true, y_pred).numpy()
-        self.assertEqual(
-            l_single,
-            l_multi,
-            "hinge multiclass must yield the same "
-            "results when given a single class "
-            "vector",
-        )
+
         n_class = 10
         n_items = 10000
         y_true = tf.one_hot(np.random.randint(0, 10, n_items), n_class)

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -55,8 +55,8 @@ class Test(TestCase):
     def test_kr_loss(self):
         loss = KR()
 
-        y_true = tf.convert_to_tensor([1.0, 1.0, 1.0, 0.0, 0.0, 0.0])
-        y_pred = tf.convert_to_tensor([0.5, 1.5, -0.5, -0.5, -1.5, 0.5])
+        y_true = binary_tf_data([1.0, 1.0, 1.0, 0.0, 0.0, 0.0])
+        y_pred = binary_tf_data([0.5, 1.5, -0.5, -0.5, -1.5, 0.5])
         loss_val = loss(y_true, y_pred).numpy()
         self.assertEqual(loss_val, np.float32(1), "KR loss must be equal to 1")
 
@@ -82,8 +82,8 @@ class Test(TestCase):
 
     def test_hinge_margin_loss(self):
         loss = HingeMargin(2.0)
-        y_true = tf.convert_to_tensor([1.0, 1.0, 1.0, 0.0, 0.0, 0.0])
-        y_pred = tf.convert_to_tensor([0.5, 1.5, -0.5, -0.5, -1.5, 0.5])
+        y_true = binary_tf_data([1.0, 1.0, 1.0, 0.0, 0.0, 0.0])
+        y_pred = binary_tf_data([0.5, 1.5, -0.5, -0.5, -1.5, 0.5])
         loss_val = loss(y_true, y_pred).numpy()
         self.assertEqual(loss_val, np.float32(4 / 6), "Hinge loss must be equal to 4/6")
         loss_val_3 = loss(tf.cast(y_true, dtype=tf.int32), y_pred).numpy()
@@ -127,8 +127,8 @@ class Test(TestCase):
     def test_hinge_multiclass_loss(self):
         multiclass_hinge = MulticlassHinge(2.0)
         hinge = HingeMargin(2.0)
-        y_true = tf.convert_to_tensor([1.0, 1.0, 1.0, 0.0, 0.0, 0.0])
-        y_pred = tf.convert_to_tensor([0.5, 1.5, -0.5, -0.5, -1.5, 0.5])
+        y_true = binary_tf_data([1.0, 1.0, 1.0, 0.0, 0.0, 0.0])
+        y_pred = binary_tf_data([0.5, 1.5, -0.5, -0.5, -1.5, 0.5])
         l_single = hinge(y_true, y_pred).numpy()
         l_multi = multiclass_hinge(y_true, y_pred).numpy()
         self.assertEqual(l_single, np.float32(4 / 6), "Hinge loss must be equal to 4/6")
@@ -246,8 +246,8 @@ class Test(TestCase):
         Assert binary losses without reduction. Three losses are tested on hardcoded
         y_true/y_pred of shape [8 elements, 1]: KR, HingeMargin and HKR.
         """
-        y_true = np.array([1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0]).reshape((8, 1))
-        y_pred = np.array([0.5, 1.1, -0.1, 0.7, -1.3, -0.4, 0.2, -0.9]).reshape((8, 1))
+        y_true = binary_tf_data([1.0, 1.0, 1.0, 1.0, 0.0, 0.0, 0.0, 0.0])
+        y_pred = binary_tf_data([0.5, 1.1, -0.1, 0.7, -1.3, -0.4, 0.2, -0.9])
 
         losses = (
             KR(reduction="none"),


### PR DESCRIPTION
This PR introduces new losses and new callbacks:

- two new losses `TauCategoricalCrossentropy` and `CategoricalHinge`
- callbacks `LossParamScheduler` to modify loss hyper-parameters during training and `LossParamLog` to log the value of parameters

Some changes have also been brought:
- the centered hinge losses (`HingeMargin` and `MulticlassHinge`) have now a `min_margin/2` on both sides
- the loss hyper-parameters `min_margin`, `alpha` and `tau` are now `tf.Variable` in order to modify them during training