### PR TITLE
Feat/orthogonalization improvements

### DIFF
--- a/deel/lip/layers.py
+++ b/deel/lip/layers.py
@@ -38,6 +38,8 @@ from .normalizers import (
     DEFAULT_EPS_SPECTRAL,
     reshaped_kernel_orthogonalization,
     DEFAULT_BETA_BJORCK,
+    DEFAULT_MAXITER_BJORCK,
+    DEFAULT_MAXITER_SPECTRAL,
 )
 from tensorflow.keras.utils import register_keras_serializable
 
@@ -183,6 +185,8 @@ class SpectralDense(keraslayers.Dense, LipschitzLayer, Condensable):
         eps_spectral=DEFAULT_EPS_SPECTRAL,
         eps_bjorck=DEFAULT_EPS_BJORCK,
         beta_bjorck=DEFAULT_BETA_BJORCK,
+        maxiter_spectral=DEFAULT_MAXITER_SPECTRAL,
+        maxiter_bjorck=DEFAULT_MAXITER_BJORCK,
         **kwargs
     ):
         """
@@ -213,6 +217,8 @@ class SpectralDense(keraslayers.Dense, LipschitzLayer, Condensable):
             eps_spectral: stopping criterion for the iterative power algorithm.
             eps_bjorck: stopping criterion Bjorck algorithm.
             beta_bjorck: beta parameter in bjorck algorithm.
+            maxiter_spectral: maximum number of iterations for the power iteration.
+            maxiter_bjorck: maximum number of iterations for bjorck algorithm.
 
         Input shape:
             N-D tensor with shape: `(batch_size, ..., input_dim)`.
@@ -243,8 +249,10 @@ class SpectralDense(keraslayers.Dense, LipschitzLayer, Condensable):
         self.set_klip_factor(k_coef_lip)
         _check_RKO_params(eps_spectral, eps_bjorck, beta_bjorck)
         self.eps_spectral = eps_spectral
-        self.beta_bjorck = beta_bjorck
         self.eps_bjorck = eps_bjorck
+        self.beta_bjorck = beta_bjorck
+        self.maxiter_bjorck = maxiter_bjorck
+        self.maxiter_spectral = maxiter_spectral
         self.u = None
         self.sig = None
         self.wbar = None
@@ -284,6 +292,8 @@ class SpectralDense(keraslayers.Dense, LipschitzLayer, Condensable):
                 self.eps_spectral,
                 self.eps_bjorck,
                 self.beta_bjorck,
+                self.maxiter_spectral,
+                self.maxiter_bjorck,
             )
             self.wbar.assign(wbar)
             self.u.assign(u)
@@ -303,6 +313,8 @@ class SpectralDense(keraslayers.Dense, LipschitzLayer, Condensable):
             "eps_spectral": self.eps_spectral,
             "eps_bjorck": self.eps_bjorck,
             "beta_bjorck": self.beta_bjorck,
+            "maxiter_spectral": self.maxiter_spectral,
+            "maxiter_bjorck": self.maxiter_bjorck,
         }
         base_config = super(SpectralDense, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
@@ -315,6 +327,8 @@ class SpectralDense(keraslayers.Dense, LipschitzLayer, Condensable):
             self.eps_spectral,
             self.eps_bjorck,
             self.beta_bjorck,
+            self.maxiter_spectral,
+            self.maxiter_bjorck,
         )
         self.kernel.assign(wbar)
         self.u.assign(u)
@@ -386,6 +400,8 @@ class SpectralConv2D(keraslayers.Conv2D, LipschitzLayer, Condensable):
         eps_spectral=DEFAULT_EPS_SPECTRAL,
         eps_bjorck=DEFAULT_EPS_BJORCK,
         beta_bjorck=DEFAULT_BETA_BJORCK,
+        maxiter_spectral=DEFAULT_MAXITER_SPECTRAL,
+        maxiter_bjorck=DEFAULT_MAXITER_BJORCK,
         **kwargs
     ):
         """
@@ -446,6 +462,8 @@ class SpectralConv2D(keraslayers.Conv2D, LipschitzLayer, Condensable):
             eps_spectral: stopping criterion for the iterative power algorithm.
             eps_bjorck: stopping criterion Bjorck algorithm.
             beta_bjorck: beta parameter in bjorck algorithm.
+            maxiter_spectral: maximum number of iterations for the power iteration.
+            maxiter_bjorck: maximum number of iterations for bjorck algorithm.
 
         This documentation reuse the body of the original keras.layers.Conv2D doc.
         """
@@ -484,6 +502,8 @@ class SpectralConv2D(keraslayers.Conv2D, LipschitzLayer, Condensable):
         self.eps_spectral = eps_spectral
         self.eps_bjorck = eps_bjorck
         self.beta_bjorck = beta_bjorck
+        self.maxiter_bjorck = maxiter_bjorck
+        self.maxiter_spectral = maxiter_spectral
 
     def build(self, input_shape):
         super(SpectralConv2D, self).build(input_shape)
@@ -520,6 +540,8 @@ class SpectralConv2D(keraslayers.Conv2D, LipschitzLayer, Condensable):
                 self.eps_spectral,
                 self.eps_bjorck,
                 self.beta_bjorck,
+                self.maxiter_spectral,
+                self.maxiter_bjorck,
             )
             self.wbar.assign(wbar)
             self.u.assign(u)
@@ -546,6 +568,8 @@ class SpectralConv2D(keraslayers.Conv2D, LipschitzLayer, Condensable):
             "eps_spectral": self.eps_spectral,
             "eps_bjorck": self.eps_bjorck,
             "beta_bjorck": self.beta_bjorck,
+            "maxiter_spectral": self.maxiter_spectral,
+            "maxiter_bjorck": self.maxiter_bjorck,
         }
         base_config = super(SpectralConv2D, self).get_config()
         return dict(list(base_config.items()) + list(config.items()))
@@ -558,6 +582,8 @@ class SpectralConv2D(keraslayers.Conv2D, LipschitzLayer, Condensable):
             self.eps_spectral,
             self.eps_bjorck,
             self.beta_bjorck,
+            self.maxiter_spectral,
+            self.maxiter_bjorck,
         )
         self.kernel.assign(wbar)
         self.u.assign(u)
@@ -609,6 +635,8 @@ class SpectralConv2DTranspose(keraslayers.Conv2DTranspose, LipschitzLayer, Conde
         eps_spectral=DEFAULT_EPS_SPECTRAL,
         eps_bjorck=DEFAULT_EPS_BJORCK,
         beta_bjorck=DEFAULT_BETA_BJORCK,
+        maxiter_spectral=DEFAULT_MAXITER_SPECTRAL,
+        maxiter_bjorck=DEFAULT_MAXITER_BJORCK,
         **kwargs
     ):
         """
@@ -674,6 +702,8 @@ class SpectralConv2DTranspose(keraslayers.Conv2DTranspose, LipschitzLayer, Conde
             eps_spectral: stopping criterion for the iterative power algorithm.
             eps_bjorck: stopping criterion Björck algorithm.
             beta_bjorck: beta parameter in Björck algorithm.
+            maxiter_spectral: maximum number of iterations for the power iteration.
+            maxiter_bjorck: maximum number of iterations for bjorck algorithm.
         """
         super().__init__(
             filters,
@@ -711,6 +741,8 @@ class SpectralConv2DTranspose(keraslayers.Conv2DTranspose, LipschitzLayer, Conde
         self.eps_spectral = eps_spectral
         self.eps_bjorck = eps_bjorck
         self.beta_bjorck = beta_bjorck
+        self.maxiter_bjorck = maxiter_bjorck
+        self.maxiter_spectral = maxiter_spectral
         self._kwargs = kwargs
 
     def build(self, input_shape):
@@ -748,6 +780,8 @@ class SpectralConv2DTranspose(keraslayers.Conv2DTranspose, LipschitzLayer, Conde
                 self.eps_spectral,
                 self.eps_bjorck,
                 self.beta_bjorck,
+                self.maxiter_spectral,
+                self.maxiter_bjorck,
             )
             wbar = tf.transpose(wbar, [0, 1, 3, 2])
             self.wbar.assign(wbar)
@@ -836,6 +870,8 @@ class SpectralConv2DTranspose(keraslayers.Conv2DTranspose, LipschitzLayer, Conde
             "eps_spectral": self.eps_spectral,
             "eps_bjorck": self.eps_bjorck,
             "beta_bjorck": self.beta_bjorck,
+            "maxiter_spectral": self.maxiter_spectral,
+            "maxiter_bjorck": self.maxiter_bjorck,
         }
         base_config = super().get_config()
         return dict(list(base_config.items()) + list(config.items()))
@@ -848,6 +884,8 @@ class SpectralConv2DTranspose(keraslayers.Conv2DTranspose, LipschitzLayer, Conde
             self.eps_spectral,
             self.eps_bjorck,
             self.beta_bjorck,
+            self.maxiter_spectral,
+            self.maxiter_bjorck,
         )
         self.kernel.assign(wbar)
         self.u.assign(u)

--- a/deel/lip/normalizers.py
+++ b/deel/lip/normalizers.py
@@ -14,6 +14,8 @@ DEFAULT_EPS_SPECTRAL = 1e-3
 DEFAULT_EPS_BJORCK = 1e-3
 DEFAULT_MAXITER_BJORCK = 15
 DEFAULT_MAXITER_SPECTRAL = 10
+SWAP_MEMORY = True
+STOP_GRAD_SPECTRAL = True
 
 
 def reshaped_kernel_orthogonalization(
@@ -106,7 +108,7 @@ def bjorck_normalization(
         (w, old_w),
         parallel_iterations=30,
         maximum_iterations=maxiter,
-        swap_memory=True,
+        swap_memory=SWAP_MEMORY,
     )
     return w
 
@@ -158,8 +160,11 @@ def _power_iteration(w, u, eps=DEFAULT_EPS_SPECTRAL, maxiter=DEFAULT_MAXITER_SPE
         (_u, _v, _old_u),
         parallel_iterations=30,
         maximum_iterations=maxiter,
-        swap_memory=True,
+        swap_memory=SWAP_MEMORY,
     )
+    if STOP_GRAD_SPECTRAL:
+        _u = tf.stop_gradient(_u)
+        _v = tf.stop_gradient(_v)
     return _u, _v
 
 

--- a/deel/lip/normalizers.py
+++ b/deel/lip/normalizers.py
@@ -61,6 +61,13 @@ def reshaped_kernel_orthogonalization(
     return W_bar, u, sigma
 
 
+def _wwtw(w):
+    if w.shape[0] > w.shape[1]:
+        return w @ (tf.transpose(w) @ w)
+    else:
+        return (w @ tf.transpose(w)) @ w
+
+
 def bjorck_normalization(
     w, eps=DEFAULT_EPS_BJORCK, beta=DEFAULT_BETA_BJORCK, maxiter=DEFAULT_MAXITER_BJORCK
 ):
@@ -89,7 +96,7 @@ def bjorck_normalization(
     # define the loop body
     def body(w, old_w):
         old_w = w
-        w = (1 + beta) * w - beta * w @ tf.transpose(w) @ w
+        w = (1 + beta) * w - beta * _wwtw(w)
         return w, old_w
 
     # apply the loop

--- a/deel/lip/normalizers.py
+++ b/deel/lip/normalizers.py
@@ -104,7 +104,7 @@ def bjorck_normalization(
         cond,
         body,
         (w, old_w),
-        parallel_iterations=1,
+        parallel_iterations=30,
         maximum_iterations=maxiter,
         swap_memory=True,
     )
@@ -156,7 +156,7 @@ def _power_iteration(w, u, eps=DEFAULT_EPS_SPECTRAL, maxiter=DEFAULT_MAXITER_SPE
         cond,
         body,
         (_u, _v, _old_u),
-        parallel_iterations=1,
+        parallel_iterations=30,
         maximum_iterations=maxiter,
         swap_memory=True,
     )

--- a/deel/lip/normalizers.py
+++ b/deel/lip/normalizers.py
@@ -94,7 +94,12 @@ def bjorck_normalization(
 
     # apply the loop
     w, old_w = tf.while_loop(
-        cond, body, (w, old_w), parallel_iterations=1, maximum_iterations=maxiter
+        cond,
+        body,
+        (w, old_w),
+        parallel_iterations=1,
+        maximum_iterations=maxiter,
+        swap_memory=True,
     )
     return w
 
@@ -141,7 +146,12 @@ def _power_iteration(w, u, eps=DEFAULT_EPS_SPECTRAL, maxiter=DEFAULT_MAXITER_SPE
 
     # apply the loop
     _u, _v, _old_u = tf.while_loop(
-        cond, body, (_u, _v, _old_u), parallel_iterations=1, maximum_iterations=maxiter
+        cond,
+        body,
+        (_u, _v, _old_u),
+        parallel_iterations=1,
+        maximum_iterations=maxiter,
+        swap_memory=True,
     )
     return _u, _v
 

--- a/deel/lip/normalizers.py
+++ b/deel/lip/normalizers.py
@@ -18,6 +18,38 @@ SWAP_MEMORY = True
 STOP_GRAD_SPECTRAL = True
 
 
+def set_swap_memory(value: bool):
+    """
+    Set the global SWAP_MEMORY to values. This function must be called before
+    constructing the model (first call of `reshaped_kernel_orthogonalization`) in
+    order to be accounted.
+
+    Args:
+        value: boolean that will be used as the swap_memory parameter in while loops
+            in spectral and bjorck algorithms.
+
+    """
+    global SWAP_MEMORY
+    SWAP_MEMORY = value
+
+
+def set_stop_grad_spectral(value: bool):
+    """
+    Set the global STOP_GRAD_SPECTRAL to values. This function must be called before
+    constructing the model (first call of `reshaped_kernel_orthogonalization`) in
+    order to be accounted.
+
+    Args:
+        value: boolean, when set to True, disable back-propagation through the power
+            iteration algorithm. The back-propagation will account how updates affects
+            the maximum singular value but not how it affects the largest singular
+            vector. When set to False, back-propagate through the while loop.
+
+    """
+    global STOP_GRAD_SPECTRAL
+    STOP_GRAD_SPECTRAL = value
+
+
 def reshaped_kernel_orthogonalization(
     kernel,
     u,

--- a/tests/test_normalizers.py
+++ b/tests/test_normalizers.py
@@ -23,9 +23,8 @@ class TestSpectralNorm(unittest.TestCase):
         kernel_shape = (15, 32)
         kernel = np.random.normal(size=kernel_shape).astype("float32")
         self._test_kernel(kernel)
-
-        # Conv kernel
-        kernel_shape = (5, 5, 64, 32)
+        # Dense kernel projection
+        kernel_shape = (32, 15)
         kernel = np.random.normal(size=kernel_shape).astype("float32")
         self._test_kernel(kernel)
 


### PR DESCRIPTION
added following optimizations in normalizers.py:
- in bjorck: choose between (WWt)W and W(WtW) to save time and memory on non-square matrices
- added `maxiter_bjorck` and `maxiter_spectral` parameters
- added globals `SWAP_MEMORY` and `STOP_GRAD_SPECTRAL` and function to set those (default values fallback to original behavior)

The way to set the two last parameters is subject to discussion, I chose this method to avoid clutter layers interfaces. 