### PR TITLE
Power iteration algorithm is now generic to any linear operator

### DIFF
--- a/deel/lip/normalizers.py
+++ b/deel/lip/normalizers.py
@@ -165,7 +165,6 @@ def _power_iteration(
     eps=DEFAULT_EPS_SPECTRAL,
     maxiter=DEFAULT_MAXITER_SPECTRAL,
     axis=None,
-    big_constant=-1,
 ):
     """Internal function that performs the power iteration algorithm to estimate the
     largest singular vector of a linear operator.
@@ -181,8 +180,6 @@ def _power_iteration(
             Defaults to DEFAULT_MAXITER_SPECTRAL.
         axis (int/list, optional): dimension along which to normalize. Can be set for
             depthwise convolution for example. Defaults to None.
-        big_constant (int, optional): Set to a large value to compute the minimum
-            singular value. Defaults to -1, to compute the maximum singular value.
 
     Returns:
         tf.Tensor: the maximum singular vector.
@@ -198,9 +195,6 @@ def _power_iteration(
         old_u = u
         v = linear_operator(u)
         u = adjoint_operator(v)
-
-        if big_constant > 0:
-            u = big_constant * old_u - u
 
         u = tf.math.l2_normalize(u, axis=axis)
 

--- a/deel/lip/normalizers.py
+++ b/deel/lip/normalizers.py
@@ -164,6 +164,7 @@ def _power_iteration(
     u,
     eps=DEFAULT_EPS_SPECTRAL,
     maxiter=DEFAULT_MAXITER_SPECTRAL,
+    axis=None,
     big_constant=-1,
 ):
     """Internal function that performs the power iteration algorithm to estimate the
@@ -178,6 +179,8 @@ def _power_iteration(
             norm(u[t] - u[t-1]) is less than eps. Defaults to DEFAULT_EPS_SPECTRAL.
         maxiter (int, optional): maximum number of iterations for the algorithm.
             Defaults to DEFAULT_MAXITER_SPECTRAL.
+        axis (int/list, optional): dimension along which to normalize. Can be set for
+            depthwise convolution for example. Defaults to None.
         big_constant (int, optional): Set to a large value to compute the minimum
             singular value. Defaults to -1, to compute the maximum singular value.
 
@@ -186,7 +189,7 @@ def _power_iteration(
     """
 
     # Prepare while loop variables
-    u = tf.math.l2_normalize(u)
+    u = tf.math.l2_normalize(u, axis=axis)
     # create a fake old_w that doesn't pass the loop condition, it will be overwritten
     old_u = u + 2 * eps
 
@@ -199,7 +202,7 @@ def _power_iteration(
         if big_constant > 0:
             u = big_constant * old_u - u
 
-        u = tf.math.l2_normalize(u)
+        u = tf.math.l2_normalize(u, axis=axis)
 
         return u, old_u
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,8 +9,8 @@ per-file-ignores =
 
 [tox:tox]
 envlist =
-    py{37,38,39,310}-tf{22,23,24,25,26,27,28,29,210,211,212,213,latest}
-    py{37,38,39,310}-lint
+    py{37,38,39,310,311}-tf{22,23,24,25,26,27,28,29,210,211,212,213,214,latest}
+    py{37,38,39,310,311}-lint
 
 [testenv]
 deps =
@@ -28,11 +28,12 @@ deps =
     tf211: tensorflow ~= 2.11.0
     tf212: tensorflow ~= 2.12.0
     tf213: tensorflow ~= 2.13.0
+    tf214: tensorflow ~= 2.14.0
 
 commands =
     python -m unittest
 
-[testenv:py{37,38,39,310}-lint]
+[testenv:py{37,38,39,310,311}-lint]
 skip_install = true
 deps =
     black

--- a/tests/test_normalizers.py
+++ b/tests/test_normalizers.py
@@ -40,7 +40,7 @@ class TestSpectralNorm(unittest.TestCase):
         ).numpy()
         SVmax = np.max(sigmas_svd)
 
-        u = rng.normal(size=(1, kernel.shape[-1]))
+        u = rng.normal(size=(1, kernel.shape[-1])).astype("float32")
         W_bar, _u, sigma = spectral_normalization(kernel, u=u, eps=1e-6)
         # Test sigma is close to the one computed with svd first run @ 1e-1
         np.testing.assert_approx_equal(


### PR DESCRIPTION
In order to easily handle power iteration computations for future new linear operators (e.g. depthwise convolution), the power iteration algorithm is made generic:
* the power iteration function takes a linear operator and its adjoint as arguments
* for each operation (for now fully connected and convolutional operations), we define their linear and adjoint operators and then use the generic power iteration to compute the maximum singular vector and value.

