### PR TITLE
Account for ImportError due to tensorflow version

### DIFF
--- a/deel/lip/layers/convolutional.py
+++ b/deel/lip/layers/convolutional.py
@@ -43,7 +43,7 @@ from .base_layer import Condensable, LipschitzLayer
 
 try:
     from keras.utils import conv_utils  # in Keras for TF >= 2.6
-except ModuleNotFoundError:
+except ImportError or ModuleNotFoundError:
     from tensorflow.python.keras.utils import conv_utils  # in TF.python for TF <= 2.5
 
 


### PR DESCRIPTION
Hello! I noticed that there was an ImportError in a test using tensorflow version 2.13.0: https://github.com/deel-ai/deel-lip/actions/runs/5545972296/job/15088178944

So I changed ``except ModuleNotFoundError:`` to ``except ImportError or ModuleNotFoundError:`` in the relevant file where the import error was occurring.