### PR TITLE
Support of TensorFlow 2.13

### DIFF
--- a/deel/lip/layers/convolutional.py
+++ b/deel/lip/layers/convolutional.py
@@ -43,8 +43,9 @@ from .base_layer import Condensable, LipschitzLayer
 
 try:
     from keras.utils import conv_utils  # in Keras for TF >= 2.6
-except ModuleNotFoundError:
-    from tensorflow.python.keras.utils import conv_utils  # in TF.python for TF <= 2.5
+except ImportError:
+    # conv_utils in tf.python for TF <= 2.5 and TF >= 2.13
+    from tensorflow.python.keras.utils import conv_utils
 
 
 def _compute_conv_lip_factor(kernel_size, strides, input_shape, data_format):

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,9 @@ per-file-ignores =
 	*/__init__.py: F401
 
 [tox:tox]
-envlist = py{37,38,39,310}-tf{22,23,24,25,26,27,28,29,latest},py{37,38,39,310}-lint
+envlist =
+    py{37,38,39,310}-tf{22,23,24,25,26,27,28,29,210,211,212,213,latest}
+    py{37,38,39,310}-lint
 
 [testenv]
 deps =
@@ -22,6 +24,11 @@ deps =
     tf27: tensorflow ~= 2.7.0
     tf28: tensorflow ~= 2.8.0
     tf29: tensorflow ~= 2.9.0
+    tf210: tensorflow ~= 2.10.0
+    tf211: tensorflow ~= 2.11.0
+    tf212: tensorflow ~= 2.12.0
+    tf213: tensorflow ~= 2.13.0
+
 commands =
     python -m unittest
 

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -226,8 +226,8 @@ def train_k_lip_model(
     )
     empirical_lip_const = evaluate_lip_const(model=model, x=x, seed=42)
     # save the model
-    model_checkpoint_path = os.path.join(logdir, "model.h5")
-    model.save(model_checkpoint_path, overwrite=True, save_format="h5")
+    model_checkpoint_path = os.path.join(logdir, "model.keras")
+    model.save(model_checkpoint_path, overwrite=True)
     del model
     K.clear_session()
     model = load_model(model_checkpoint_path)
@@ -1050,7 +1050,7 @@ class TestSpectralConv2DTranspose(unittest.TestCase):
 
         # Test saving/loading model
         with tempfile.TemporaryDirectory() as tmpdir:
-            model_path = os.path.join(tmpdir, "model.h5")
+            model_path = os.path.join(tmpdir, "model.keras")
             model.save(model_path)
             tf.keras.models.load_model(model_path)
 

--- a/tests/test_normalizers.py
+++ b/tests/test_normalizers.py
@@ -15,7 +15,7 @@ from deel.lip.normalizers import (
 )
 from deel.lip.utils import _padding_circular
 
-np.random.seed(42)
+rng = np.random.default_rng(42)
 
 
 class TestSpectralNorm(unittest.TestCase):
@@ -24,11 +24,11 @@ class TestSpectralNorm(unittest.TestCase):
     def test_spectral_normalization(self):
         # Dense kernel
         kernel_shape = (15, 32)
-        kernel = np.random.normal(size=kernel_shape).astype("float32")
+        kernel = rng.normal(size=kernel_shape).astype("float32")
         self._test_kernel(kernel)
         # Dense kernel projection
         kernel_shape = (32, 15)
-        kernel = np.random.normal(size=kernel_shape).astype("float32")
+        kernel = rng.normal(size=kernel_shape).astype("float32")
         self._test_kernel(kernel)
 
     def _test_kernel(self, kernel):
@@ -40,7 +40,8 @@ class TestSpectralNorm(unittest.TestCase):
         ).numpy()
         SVmax = np.max(sigmas_svd)
 
-        W_bar, _u, sigma = spectral_normalization(kernel, u=None, eps=1e-6)
+        u = rng.normal(size=(1, kernel.shape[-1]))
+        W_bar, _u, sigma = spectral_normalization(kernel, u=u, eps=1e-6)
         # Test sigma is close to the one computed with svd first run @ 1e-1
         np.testing.assert_approx_equal(
             sigma, SVmax, 1, "test failed with kernel_shape " + str(kernel.shape)


### PR DESCRIPTION
TensorFlow 2.13 introduces three problems raising errors in unit tests:

- Module `conv_utils` from Keras, required for our convolutional layers, has been moved (again) in a different Keras folder. Depending on TF version, we import this module from different paths.
- Serialization/deserialization of h5 models with custom objects (here, custom initializer) is not supported anymore in TF 2.13. The new `.keras` format is now preferred, instead of h5 format.
- One of our unit test was failing (comparison of SVD and power iteration for a Dense kernel). This is not a problem from TF 2.13 but from non-deterministic computation: for some random cases, the power iteration algorithm had difficulties to converge close enough to the true value. This failing test is now deterministic with seeded kernel and initialization u.