### PR TITLE
New cross-entropy losses with temperature

### DIFF
--- a/deel/lip/losses.py
+++ b/deel/lip/losses.py
@@ -9,7 +9,12 @@ This module contains losses used in Wasserstein distance estimation. See
 from functools import partial
 import numpy as np
 import tensorflow as tf
-from tensorflow.keras.losses import categorical_crossentropy, Loss, Reduction
+from tensorflow.keras.losses import (
+    categorical_crossentropy,
+    sparse_categorical_crossentropy,
+    Loss,
+    Reduction,
+)
 from tensorflow.keras.utils import register_keras_serializable
 
 
@@ -492,4 +497,33 @@ class TauCategoricalCrossentropy(Loss):
     def get_config(self):
         config = {"tau": self.tau.numpy()}
         base_config = super(TauCategoricalCrossentropy, self).get_config()
+        return dict(list(base_config.items()) + list(config.items()))
+
+
+@register_keras_serializable("deel-lip", "TauSparseCategoricalCrossentropy")
+class TauSparseCategoricalCrossentropy(Loss):
+    def __init__(
+        self, tau, reduction=Reduction.AUTO, name="TauSparseCategoricalCrossentropy"
+    ):
+        """
+        Similar to original sparse categorical crossentropy, but with a settable
+        temperature parameter.
+
+        Args:
+            tau (float): temperature parameter.
+            reduction: reduction of the loss, passed to original loss.
+            name (str): name of the loss
+        """
+        self.tau = tf.Variable(tau, dtype=tf.float32)
+        super().__init__(name=name, reduction=reduction)
+
+    def call(self, y_true, y_pred):
+        return (
+            sparse_categorical_crossentropy(y_true, self.tau * y_pred, from_logits=True)
+            / self.tau
+        )
+
+    def get_config(self):
+        config = {"tau": self.tau.numpy()}
+        base_config = super().get_config()
         return dict(list(base_config.items()) + list(config.items()))


### PR DESCRIPTION
This PR introduces two new cross-entropy losses based on Keras standard losses and with a settable temperature for softmax:

- `TauSparseCategoricalCrossentropy` equivalent to Keras `SparseCategoricalCrossentropy`
- `TauBinaryCrossentropy` equivalent to Keras `BinaryCrossentropy`