### PR TITLE
Better SVD computation for convolution 

### DIFF
--- a/.github/workflows/python-linters.yml
+++ b/.github/workflows/python-linters.yml
@@ -16,9 +16,9 @@ jobs:
         python-version: [3.7, "3.10"]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -24,9 +24,9 @@ jobs:
             tf-version: latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/deel/lip/compute_layer_sv.py
+++ b/deel/lip/compute_layer_sv.py
@@ -53,9 +53,15 @@ def _generate_conv_matrix(layer, input_sizes):
     Returns:
         np.array: the equivalent matrix of the convolutional layer.
     """
+    # Clone layer (as a model) and remove bias and activation
     single_layer_model = tf.keras.models.Sequential(
         [tf.keras.layers.Input(input_sizes[1:]), layer]
     )
+    single_layer_model = tf.keras.models.clone_model(single_layer_model)
+    single_layer_model.set_weights(layer.get_weights())
+    single_layer_model.layers[0].use_bias = False
+    single_layer_model.layers[0].activation = None
+
     dirac_inp = np.zeros((input_sizes[2],) + input_sizes[1:])  # Line by line generation
     in_size = input_sizes[1] * input_sizes[2]
     channel_in = input_sizes[-1]

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setuptools.setup(
     url="https://github.com/deel-ai/deel-lip",
     packages=setuptools.find_namespace_packages(include=["deel.*"]),
     include_package_data=True,
-    install_requires=["numpy", "tensorflow~=2.2"],
+    install_requires=["numpy", "scipy", "tensorflow~=2.2"],
     license="MIT",
     extras_require={"dev": dev_requires, "docs": docs_requires},
     classifiers=[

--- a/tests/test_compute_layer_sv.py
+++ b/tests/test_compute_layer_sv.py
@@ -343,6 +343,23 @@ class LipschitzLayersSVTest(unittest.TestCase):
                     test_SVmin=False,
                     callbacks=[],
                 ),
+                dict(  # SpectralConv2D with bias and activation
+                    layer_type=SpectralConv2D,
+                    layer_params={
+                        "filters": 2,
+                        "kernel_size": (3, 3),
+                        "activation": "relu",
+                    },
+                    batch_size=100,
+                    steps_per_epoch=125,
+                    epochs=5,
+                    input_shape=(5, 5, 1),
+                    k_lip_data=1.0,
+                    k_lip_model=1.0,
+                    k_lip_tolerance_factor=1.02,
+                    test_SVmin=False,
+                    callbacks=[],
+                ),
                 dict(
                     layer_type=SpectralConv2D,
                     layer_params={


### PR DESCRIPTION
- The creation of the equivalent convolution matrix requires to remove bias and activation in the convolutional layer. This wasn't done before. This is now fixed.
- The equivalent matrix is now sparse and the SVD computation is also based on sparse matrices. Note that the smallest singular value is very expensive to compute with `scipy.sparse`