### PR TITLE
deel-lip supports until TensorFlow 2.15

### DIFF
--- a/.github/workflows/python-linters.yml
+++ b/.github/workflows/python-linters.yml
@@ -16,9 +16,9 @@ jobs:
         python-version: [3.7, "3.10"]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -21,7 +21,9 @@ jobs:
           - python-version: 3.9
             tf-version: 2.7
           - python-version: "3.10"
-            tf-version: latest
+            tf-version: 2.11
+          - python-version: "3.10"
+            tf-version: 2.15
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -24,9 +24,9 @@ jobs:
             tf-version: latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/README.md
+++ b/README.md
@@ -40,6 +40,18 @@ distance estimation.
 This library provides an efficient implementation of **k-Lispchitz
 layers for keras**.
 
+> [!CAUTION]
+> **Incompatibility with TensorFlow >= 2.16 and Keras 3**
+>
+> Due to significant changes introduced in TensorFlow version 2.16 and Keras 3, this
+> package is currently incompatible with TensorFlow versions 2.16 and above. Users are
+> advised to use TensorFlow versions lower than 2.16 to ensure compatibility and proper
+> functionality of this package.
+>
+> We are actively working on updating the package to support Keras 3. Please stay tuned
+> for updates. For now, make sure to install an earlier version of TensorFlow by
+> specifying it in your environment.
+
 ## 📚 Table of contents
 
 - [📚 Table of contents](#-table-of-contents)

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@ per-file-ignores =
 
 [tox:tox]
 envlist =
-    py{37,38,39,310,311}-tf{22,23,24,25,26,27,28,29,210,211,212,213,214,latest}
+    py{37,38,39,310,311}-tf{22,23,24,25,26,27,28,29,210,211,212,213,214,215,216,217,latest}
     py{37,38,39,310,311}-lint
 
 [testenv]
@@ -29,6 +29,9 @@ deps =
     tf212: tensorflow ~= 2.12.0
     tf213: tensorflow ~= 2.13.0
     tf214: tensorflow ~= 2.14.0
+    tf215: tensorflow ~= 2.15.0
+    tf216: tensorflow ~= 2.16.0
+    tf217: tensorflow ~= 2.17.0
 
 commands =
     python -m unittest

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,10 +21,12 @@ deps =
     tf24: tensorflow ~= 2.4.0
     tf25: tensorflow ~= 2.5.0
     tf26: tensorflow ~= 2.6.0
+    tf27: numpy==1.23.5
     tf27: tensorflow ~= 2.7.0
     tf28: tensorflow ~= 2.8.0
     tf29: tensorflow ~= 2.9.0
     tf210: tensorflow ~= 2.10.0
+    tf211: numpy==1.24.4
     tf211: tensorflow ~= 2.11.0
     tf212: tensorflow ~= 2.12.0
     tf213: tensorflow ~= 2.13.0

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setuptools.setup(
     url="https://github.com/deel-ai/deel-lip",
     packages=setuptools.find_namespace_packages(include=["deel.*"]),
     include_package_data=True,
-    install_requires=["numpy", "tensorflow~=2.2"],
+    install_requires=["numpy", "tensorflow >= 2.2.0, < 2.16.0"],
     license="MIT",
     extras_require={"dev": dev_requires, "docs": docs_requires},
     classifiers=[


### PR DESCRIPTION
Because of several changes in Keras 3 for TensorFlow 2.16 and above, deel-lip does not support latest TF versions.

- Constraints on TensorFlow dependency (>= 2.2 and < 2.16) in `setup.py`
- Warning message in README