### PR TITLE
Update Python versions in GitHub actions

### DIFF
--- a/.github/workflows/python-linters.yml
+++ b/.github/workflows/python-linters.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.7, "3.10"]
+        python-version: [3.8, "3.10"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -16,7 +16,7 @@ jobs:
       max-parallel: 4
       matrix:
         include:
-          - python-version: 3.7
+          - python-version: 3.8
             tf-version: 2.3
           - python-version: 3.9
             tf-version: 2.7

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ deps =
     packaging
     tf22: protobuf == 3.20.3
     tf22: tensorflow ~= 2.2.0
+    py38-tf23: protobuf == 3.20.3
     tf23: tensorflow ~= 2.3.0
     tf24: tensorflow ~= 2.4.0
     tf25: tensorflow ~= 2.5.0


### PR DESCRIPTION
Python 3.7 is now deprecated and is not available anymore in Ubuntu images.
This PR fixes CI tests with Python 3.7 to 3.8 in GitHub actions.
In the long term, we should update all these tests with more recent Python and TensorFlow compatible versions.