### PR TITLE
feat: change Lipschitz cst estimation to Jacobian method

### DIFF
--- a/tests/test_compute_layer_sv.py
+++ b/tests/test_compute_layer_sv.py
@@ -2,8 +2,7 @@
 # rights reserved. DEEL is a research program operated by IVADO, IRT Saint Exupéry,
 # CRIAQ and ANITI - https://www.deel.ai/
 # =====================================================================================
-"""Tests for singular value computation (in compute_layer_sv.py)
-"""
+"""Tests for singular value computation (in compute_layer_sv.py)"""
 import os
 import pprint
 import unittest

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -224,7 +224,7 @@ def train_k_lip_model(
         linear_generator(batch_size, input_shape, kernel),
         steps=10,
     )
-    empirical_lip_const = evaluate_lip_const(model=model, x=x, seed=42)
+    empirical_lip_const = evaluate_lip_const(model=model, x=x)
     # save the model
     model_checkpoint_path = os.path.join(logdir, "model.keras")
     model.save(model_checkpoint_path, overwrite=True)
@@ -237,7 +237,7 @@ def train_k_lip_model(
         linear_generator(batch_size, input_shape, kernel),
         steps=10,
     )
-    from_empirical_lip_const = evaluate_lip_const(model=model, x=x, seed=42)
+    from_empirical_lip_const = evaluate_lip_const(model=model, x=x)
     # log metrics
     file_writer = tf.summary.create_file_writer(os.path.join(logdir, "metrics"))
     file_writer.set_as_default()


### PR DESCRIPTION
To estimate the Lipschitz constant of a model, we now use the Jacobian method that is more robust than random perturbations (subject to numerical errors).

The Jacobian method computes Jacobians for a batch of inputs and gets the max singular values of each Jacobian matrix, corresponding to the local Lipschitz constant. The function then returns the greatest Lipschitz constant estimation in the batch.